### PR TITLE
Add velocity command interface

### DIFF
--- a/src/mr2_can_bus_core/include/mr2_can_bus_core/can_device.hpp
+++ b/src/mr2_can_bus_core/include/mr2_can_bus_core/can_device.hpp
@@ -34,9 +34,10 @@ public:
                             std::vector<double*> & eff) = 0;
 
   /**
-   * Export command array pointers (usually position commands).
+   * Export command array pointers for position and velocity commands.
    */
-  virtual void export_command(std::vector<double*> & cmd) = 0;
+  virtual void export_command(std::vector<double*> & pos,
+                              std::vector<double*> & vel) = 0;
 
 protected:
   /** Shorthand for sending on the appropriate bus */

--- a/src/mr2_rover_description/urdf/single_joint.urdf.xacro
+++ b/src/mr2_rover_description/urdf/single_joint.urdf.xacro
@@ -18,6 +18,7 @@
 
     <joint name="joint1">
       <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
       <state_interface name="effort"/>


### PR DESCRIPTION
## Summary
- expose both position and velocity command handles from the CAN hardware interface
- teach the AK servo plugin to send velocity setpoints
- extend CAN device base class to export separate position and velocity command pointers
- initialize AK servo state/command storage before registering CAN callback to avoid race
- declare velocity command interface in single joint URDF

## Testing
- `git pull` *(fails: There is no tracking information for the current branch)*
- `apt-get update`
- `colcon build --packages-select mr2_rover_description` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_6891c38d941c83258e1331e8c101a04e