### PR TITLE
Fix filter numbering in traversability filter chain

### DIFF
--- a/src/mr2_autonomous/config/filter_chain.yaml
+++ b/src/mr2_autonomous/config/filter_chain.yaml
@@ -12,7 +12,7 @@ grid_map_filters:
         name: buffer_normalizer
         type: gridMapFilters/BufferNormalizerFilter
 
-      filter3:  # Inpainting으로 결측값 보간
+      filter2:  # Inpainting으로 결측값 보간
         name: inpaint
         type: gridMapCv/InpaintFilter
         params:
@@ -20,7 +20,7 @@ grid_map_filters:
           output_layer: elevation_inpainted
           radius: 0.10
 
-      filter4:  # 반경 평균화로 노이즈 저감
+      filter3:  # 반경 평균화로 노이즈 저감
         name: mean_in_radius
         type: gridMapFilters/MeanInRadiusFilter
         params:
@@ -28,7 +28,7 @@ grid_map_filters:
           output_layer: elevation_smooth
           radius: 0.10
 
-      filter5:  # 표면 법선 벡터 계산
+      filter4:  # 표면 법선 벡터 계산
         name: surface_normals
         type: gridMapFilters/NormalVectorsFilter
         params:
@@ -37,28 +37,28 @@ grid_map_filters:
           radius:                   0.10
           normal_vector_positive_axis: z
 
-      filter6:  # 법선 벡터를 색상으로 시각화
+      filter5:  # 법선 벡터를 색상으로 시각화
         name: normal_color_map
         type: gridMapFilters/NormalColorMapFilter
         params:
           input_layers_prefix: normal_vectors_
           output_layer:       normal_color
 
-      filter7:  # 경사도(slope) 계산
+      filter6:  # 경사도(slope) 계산
         name: slope
         type: gridMapFilters/MathExpressionFilter
         params:
           output_layer: slope
           expression: acos(normal_vectors_z)
 
-      filter8:  # 거칠기(roughness) 계산
+      filter7:  # 거칠기(roughness) 계산
         name: roughness
         type: gridMapFilters/MathExpressionFilter
         params:
           output_layer: roughness
           expression: abs(elevation_inpainted - elevation_smooth)
 
-      filter9:  # 슬로프 기반 에지 검출
+      filter8:  # 슬로프 기반 에지 검출
         name: edge_detection
         type: gridMapFilters/SlidingWindowMathExpressionFilter
         params:
@@ -74,7 +74,7 @@ grid_map_filters:
           edge_handling:      crop   # options: inside, crop, empty, mean
           window_length:      0.05   # [m]
 
-      filter10:  # 통행 가능도(traversability) 계산
+      filter9:  # 통행 가능도(traversability) 계산
         name: traversability
         type: gridMapFilters/MathExpressionFilter
         params:
@@ -83,7 +83,7 @@ grid_map_filters:
             0.5 * (1.0 - (slope     / 0.6)) +
             0.5 * (1.0 - (roughness / 0.1))
 
-      filter11:  # 하한(0) 클램핑
+      filter10:  # 하한(0) 클램핑
         name: traversability_lower_threshold
         type: gridMapFilters/ThresholdFilter
         params:
@@ -91,7 +91,7 @@ grid_map_filters:
           lower_threshold: 0.0
           set_to:          0.0
 
-      filter12:  # 상한(1) 클램핑
+      filter11:  # 상한(1) 클램핑
         name: traversability_upper_threshold
         type: gridMapFilters/ThresholdFilter
         params:


### PR DESCRIPTION
## Summary
- ensure grid map filters are numbered consecutively so all filters run

## Testing
- `colcon build --packages-select mr2_autonomous`
- `colcon test --packages-select mr2_autonomous` *(fails: ModuleNotFoundError: No module named 'ament_pep257')*


------
https://chatgpt.com/codex/tasks/task_e_6894b2e4238083258349da6e4eb7f9f5