### PR TITLE
Add manipulator joint trajectory controller

### DIFF
--- a/src/mr2_rover_description/config/controllers.yaml
+++ b/src/mr2_rover_description/config/controllers.yaml
@@ -9,6 +9,8 @@ controller_manager:
 
     rover_controller:
       type: mr2_rover_control/TwistToCommandsController
+    manipulator_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
 
 rover_controller:
   ros__parameters:
@@ -28,3 +30,18 @@ rover_controller:
     max_steer: 0.6
     twist_timeout: 0.5
     cmd_vel_topic: /cmd_vel
+
+manipulator_controller:
+  ros__parameters:
+    joints:
+      - arm_j1
+      - arm_j2
+      - arm_j3
+      - arm_j4
+      - arm_j5
+      - arm_j6
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity


### PR DESCRIPTION
## Summary
- add joint trajectory controller for arm joints in rover controllers config

## Testing
- `colcon build --packages-select mr2_rover_description`
- `colcon test --packages-select mr2_rover_description` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68959bdae3788325a34264d0867b7995