### PR TITLE
Propagate velocity and effort through CAN hardware interface

### DIFF
--- a/src/mr2_can_hardware_interface/CMakeLists.txt
+++ b/src/mr2_can_hardware_interface/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(mr2_can_bus_core REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(transmission_interface REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED src/can_hw.cpp)
 
@@ -17,7 +18,8 @@ ament_target_dependencies(${PROJECT_NAME}
   mr2_can_bus_core
   hardware_interface
   pluginlib
-  rclcpp)
+  rclcpp
+  transmission_interface)
 
 pluginlib_export_plugin_description_file(hardware_interface plugin.xml)
 

--- a/src/mr2_can_hardware_interface/package.xml
+++ b/src/mr2_can_hardware_interface/package.xml
@@ -15,6 +15,7 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>transmission_interface</depend>
 
   <!-- Export the plugin -->
   <export>

--- a/src/mr2_can_hardware_interface/src/can_hw.cpp
+++ b/src/mr2_can_hardware_interface/src/can_hw.cpp
@@ -1,11 +1,20 @@
+#include <algorithm>
 #include <memory>
-#include <vector>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "pluginlib/class_loader.hpp"
+
+#include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
+#include "transmission_interface/simple_transmission_loader.hpp"
+#include "transmission_interface/transmission.hpp"
+#include "transmission_interface/transmission_interface_exception.hpp"
 
 #include "mr2_can_bus_core/can_device.hpp"
 
@@ -21,106 +30,612 @@ public:
   CanHW() = default;
   ~CanHW() override = default;
 
-  // ---------------- Lifecycle hooks ----------------------------------
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override
   {
     if (SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+    {
       return CallbackReturn::ERROR;
+    }
 
-    // Local node for parameters / logging
-    node_   = rclcpp::Node::make_shared("can_hw");
+    node_ = rclcpp::Node::make_shared("can_hw");
 
-    // Device plugin loader for CanDevice plugins exported under mr2_can_bus_core
-    try {
+    try
+    {
       loader_ = std::make_shared<pluginlib::ClassLoader<CanDevice>>("mr2_can_bus_core", "CanDevice");
-    } catch (const pluginlib::PluginlibException & ex) {
+    }
+    catch (const pluginlib::PluginlibException & ex)
+    {
       RCLCPP_ERROR(node_->get_logger(), "Pluginlib load error: %s", ex.what());
       return CallbackReturn::ERROR;
     }
 
-    // --- create device instances, one per <joint> block ----------------
-    for (const auto & joint : info_.joints) {
-      const auto & params = joint.parameters;
-      auto it = params.find("device_plugin");
-      if (it == params.end()) {
-        RCLCPP_ERROR(node_->get_logger(), "Joint %s missing <device_plugin> param", joint.name.c_str());
-        return CallbackReturn::ERROR;
-      }
-      const std::string & plugin_name = it->second;
+    joint_index_.clear();
+    actuator_index_.clear();
+    joints_.clear();
+    actuators_.clear();
+    transmissions_.clear();
+    pos_ptrs_.clear();
+    vel_ptrs_.clear();
+    eff_ptrs_.clear();
+    cmd_ptrs_.clear();
+    devs_.clear();
 
-      std::shared_ptr<CanDevice> dev;
-      try {
-        dev = loader_->createSharedInstance(plugin_name);
-      } catch (const pluginlib::PluginlibException & ex) {
-        RCLCPP_ERROR(node_->get_logger(), "Failed to load device plugin %s: %s",
-                     plugin_name.c_str(), ex.what());
-        return CallbackReturn::ERROR;
-      }
+    transmission_interface::SimpleTransmissionLoader simple_loader;
+    transmission_interface::FourBarLinkageTransmissionLoader four_bar_loader;
 
-      try {
-        dev->configure(joint, node_.get());
-      } catch (const std::exception & ex) {
-        RCLCPP_ERROR(node_->get_logger(), "Device %s configure() threw: %s", joint.name.c_str(), ex.what());
+    for (const auto & joint : info_.joints)
+    {
+      if (joint.command_interfaces.size() != 1 ||
+          joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Joint %s must expose a single position command interface",
+          joint.name.c_str());
         return CallbackReturn::ERROR;
       }
 
-      devs_.push_back(std::move(dev));
+      auto & joint_data = get_joint(joint.name);
+
+      bool position_found = false;
+      joint_data.has_velocity = false;
+      joint_data.has_effort = false;
+
+      for (const auto & state_interface : joint.state_interfaces)
+      {
+        if (state_interface.name == hardware_interface::HW_IF_POSITION)
+        {
+          position_found = true;
+        }
+        else if (state_interface.name == hardware_interface::HW_IF_VELOCITY)
+        {
+          joint_data.has_velocity = true;
+        }
+        else if (state_interface.name == hardware_interface::HW_IF_EFFORT)
+        {
+          joint_data.has_effort = true;
+        }
+        else
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Joint %s has unsupported state interface '%s'",
+            joint.name.c_str(), state_interface.name.c_str());
+          return CallbackReturn::ERROR;
+        }
+      }
+
+      if (!position_found)
+      {
+        RCLCPP_ERROR(node_->get_logger(),
+          "Joint %s must expose at least a position state interface", joint.name.c_str());
+        return CallbackReturn::ERROR;
+      }
+
+      const auto plugin_it = joint.parameters.find("device_plugin");
+      if (plugin_it == joint.parameters.end())
+      {
+        RCLCPP_ERROR(node_->get_logger(),
+          "Joint %s missing <param name=\"device_plugin\">", joint.name.c_str());
+        return CallbackReturn::ERROR;
+      }
+
+      const auto actuator_it = joint.parameters.find("actuator");
+      joint_data.actuator_name =
+        actuator_it != joint.parameters.end() ? actuator_it->second : joint.name;
+
+      auto & actuator = get_actuator(joint_data.actuator_name);
+
+      if (!actuator.configured)
+      {
+        std::shared_ptr<CanDevice> dev;
+        try
+        {
+          dev = loader_->createSharedInstance(plugin_it->second);
+        }
+        catch (const pluginlib::PluginlibException & ex)
+        {
+          RCLCPP_ERROR(node_->get_logger(), "Failed to load device plugin %s: %s",
+            plugin_it->second.c_str(), ex.what());
+          return CallbackReturn::ERROR;
+        }
+
+        try
+        {
+          dev->configure(joint, node_.get());
+        }
+        catch (const std::exception & ex)
+        {
+          RCLCPP_ERROR(node_->get_logger(), "Device %s configure() threw: %s",
+            joint.name.c_str(), ex.what());
+          return CallbackReturn::ERROR;
+        }
+
+        const auto pos_idx = pos_ptrs_.size();
+        const auto vel_idx = vel_ptrs_.size();
+        const auto eff_idx = eff_ptrs_.size();
+        const auto cmd_idx = cmd_ptrs_.size();
+
+        dev->export_state(pos_ptrs_, vel_ptrs_, eff_ptrs_);
+        dev->export_command(cmd_ptrs_);
+
+        actuator.state_ptr = pos_ptrs_.size() > pos_idx ? pos_ptrs_[pos_idx] : nullptr;
+        actuator.velocity_ptr = vel_ptrs_.size() > vel_idx ? vel_ptrs_[vel_idx] : nullptr;
+        actuator.effort_ptr = eff_ptrs_.size() > eff_idx ? eff_ptrs_[eff_idx] : nullptr;
+        actuator.command_ptr = cmd_ptrs_.size() > cmd_idx ? cmd_ptrs_[cmd_idx] : nullptr;
+
+        if (!actuator.state_ptr || !actuator.command_ptr)
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Device for actuator %s failed to export state/command interfaces",
+            actuator.name.c_str());
+          return CallbackReturn::ERROR;
+        }
+
+        actuator.configured = true;
+        devs_.push_back(std::move(dev));
+      }
     }
 
-    // collect state / command pointers --------------------------------
-    for (auto & dev : devs_) {
-      dev->export_state(pos_ptrs_, vel_ptrs_, eff_ptrs_);
-      dev->export_command(cmd_ptrs_);
+    for (const auto & transmission_info : info_.transmissions)
+    {
+      std::shared_ptr<transmission_interface::Transmission> transmission;
+      try
+      {
+        if (transmission_info.type == "transmission_interface/SimpleTransmission")
+        {
+          transmission = simple_loader.load(transmission_info);
+        }
+        else if (transmission_info.type == "transmission_interface/FourBarLinkageTransmission")
+        {
+          transmission = four_bar_loader.load(transmission_info);
+        }
+        else
+        {
+          RCLCPP_ERROR(node_->get_logger(), "Unsupported transmission type '%s'",
+            transmission_info.type.c_str());
+          return CallbackReturn::ERROR;
+        }
+      }
+      catch (const transmission_interface::TransmissionInterfaceException & ex)
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Error while loading transmission '%s': %s",
+          transmission_info.name.c_str(), ex.what());
+        return CallbackReturn::ERROR;
+      }
+
+      if (!transmission)
+      {
+        RCLCPP_ERROR(node_->get_logger(),
+          "Loader returned null transmission for '%s'", transmission_info.name.c_str());
+        return CallbackReturn::ERROR;
+      }
+
+      std::vector<transmission_interface::JointHandle> joint_handles;
+      joint_handles.reserve(transmission_info.joints.size() * 3);
+
+      auto make_joint_handle =
+        [&](const std::string & joint_name, const std::string & interface) -> bool
+      {
+        auto & joint = get_joint(joint_name);
+        double * passthrough = nullptr;
+
+        if (interface == hardware_interface::HW_IF_POSITION)
+        {
+          passthrough = &joint.position_transmission;
+        }
+        else if (interface == hardware_interface::HW_IF_VELOCITY)
+        {
+          if (!joint.has_velocity)
+          {
+            RCLCPP_ERROR(node_->get_logger(),
+              "Transmission requests velocity interface for joint %s, but it is not available",
+              joint_name.c_str());
+            return false;
+          }
+          passthrough = &joint.velocity_transmission;
+        }
+        else if (interface == hardware_interface::HW_IF_EFFORT)
+        {
+          if (!joint.has_effort)
+          {
+            RCLCPP_ERROR(node_->get_logger(),
+              "Transmission requests effort interface for joint %s, but it is not available",
+              joint_name.c_str());
+            return false;
+          }
+          passthrough = &joint.effort_transmission;
+        }
+        else
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Transmission requests unsupported joint interface '%s' for %s",
+            interface.c_str(), joint_name.c_str());
+          return false;
+        }
+
+        joint_handles.emplace_back(joint_name, interface, passthrough);
+        return true;
+      };
+
+      for (const auto & joint_info : transmission_info.joints)
+      {
+        if (joint_info.state_interfaces.empty())
+        {
+          if (!make_joint_handle(joint_info.name, hardware_interface::HW_IF_POSITION))
+          {
+            return CallbackReturn::ERROR;
+          }
+          auto & joint = get_joint(joint_info.name);
+          if (joint.has_velocity &&
+            !make_joint_handle(joint_info.name, hardware_interface::HW_IF_VELOCITY))
+          {
+            return CallbackReturn::ERROR;
+          }
+          if (joint.has_effort &&
+            !make_joint_handle(joint_info.name, hardware_interface::HW_IF_EFFORT))
+          {
+            return CallbackReturn::ERROR;
+          }
+        }
+        else
+        {
+          for (const auto & interface : joint_info.state_interfaces)
+          {
+            if (!make_joint_handle(joint_info.name, interface))
+            {
+              return CallbackReturn::ERROR;
+            }
+          }
+        }
+      }
+
+      std::vector<transmission_interface::ActuatorHandle> actuator_handles;
+      actuator_handles.reserve(transmission_info.actuators.size() * 3);
+
+      auto make_actuator_handle =
+        [&](const std::string & actuator_name, const std::string & interface,
+          bool is_command) -> bool
+      {
+        auto & actuator = get_actuator(actuator_name);
+        double * passthrough = nullptr;
+
+        if (interface == hardware_interface::HW_IF_POSITION)
+        {
+          passthrough = &actuator.position_transmission;
+        }
+        else if (interface == hardware_interface::HW_IF_VELOCITY)
+        {
+          if (!actuator.velocity_ptr)
+          {
+            RCLCPP_ERROR(node_->get_logger(),
+              "Transmission requests velocity %s interface for actuator %s, but device did not export it",
+              is_command ? "command" : "state", actuator_name.c_str());
+            return false;
+          }
+          passthrough = &actuator.velocity_transmission;
+        }
+        else if (interface == hardware_interface::HW_IF_EFFORT)
+        {
+          if (!actuator.effort_ptr)
+          {
+            RCLCPP_ERROR(node_->get_logger(),
+              "Transmission requests effort %s interface for actuator %s, but device did not export it",
+              is_command ? "command" : "state", actuator_name.c_str());
+            return false;
+          }
+          passthrough = &actuator.effort_transmission;
+        }
+        else
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Transmission requests unsupported actuator interface '%s' for %s",
+            interface.c_str(), actuator_name.c_str());
+          return false;
+        }
+
+        actuator_handles.emplace_back(actuator_name, interface, passthrough);
+        return true;
+      };
+
+      for (const auto & actuator_info : transmission_info.actuators)
+      {
+        auto & actuator = get_actuator(actuator_info.name);
+
+        if (!actuator.configured)
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Transmission '%s' references actuator '%s' with no configured device",
+            transmission_info.name.c_str(), actuator_info.name.c_str());
+          return CallbackReturn::ERROR;
+        }
+
+        std::unordered_set<std::string> added_interfaces;
+
+        auto ensure_handle =
+          [&](const std::string & interface, bool is_command) -> bool
+        {
+          if (!added_interfaces.insert(interface).second)
+          {
+            return true;
+          }
+          return make_actuator_handle(actuator_info.name, interface, is_command);
+        };
+
+        if (actuator_info.state_interfaces.empty())
+        {
+          if (!ensure_handle(hardware_interface::HW_IF_POSITION, false))
+          {
+            return CallbackReturn::ERROR;
+          }
+          if (actuator.velocity_ptr &&
+            !ensure_handle(hardware_interface::HW_IF_VELOCITY, false))
+          {
+            return CallbackReturn::ERROR;
+          }
+          if (actuator.effort_ptr &&
+            !ensure_handle(hardware_interface::HW_IF_EFFORT, false))
+          {
+            return CallbackReturn::ERROR;
+          }
+        }
+        else
+        {
+          for (const auto & interface : actuator_info.state_interfaces)
+          {
+            if (!ensure_handle(interface, false))
+            {
+              return CallbackReturn::ERROR;
+            }
+          }
+        }
+
+        for (const auto & interface : actuator_info.command_interfaces)
+        {
+          if (!ensure_handle(interface, true))
+          {
+            return CallbackReturn::ERROR;
+          }
+        }
+      }
+
+      try
+      {
+        transmission->configure(joint_handles, actuator_handles);
+      }
+      catch (const transmission_interface::TransmissionInterfaceException & ex)
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Error while configuring transmission '%s': %s",
+          transmission_info.name.c_str(), ex.what());
+        return CallbackReturn::ERROR;
+      }
+
+      transmissions_.push_back(std::move(transmission));
     }
 
-    if (pos_ptrs_.size() != info_.joints.size()) {
-      RCLCPP_ERROR(node_->get_logger(), "Mismatch: %zu joints vs %zu pos-ptrs", info_.joints.size(), pos_ptrs_.size());
+    if (transmissions_.empty())
+    {
+      RCLCPP_ERROR(node_->get_logger(), "No transmissions defined for CAN hardware interface");
       return CallbackReturn::ERROR;
     }
 
-    RCLCPP_INFO(node_->get_logger(), "CanHW initialised: %zu joints, %zu device plugins",
-                info_.joints.size(), devs_.size());
+    RCLCPP_INFO(node_->get_logger(), "CanHW initialised: %zu joints, %zu actuators, %zu transmissions",
+      joints_.size(), actuators_.size(), transmissions_.size());
+
     return CallbackReturn::SUCCESS;
   }
 
-  // ---------------- Interface export ----------------------------------
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
-    std::vector<hardware_interface::StateInterface> sis;
-    for (size_t i = 0; i < info_.joints.size(); ++i) {
-      sis.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION, pos_ptrs_[i]);
-      sis.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, vel_ptrs_[i]);
-      sis.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_EFFORT,   eff_ptrs_[i]);
+    std::vector<hardware_interface::StateInterface> interfaces;
+    interfaces.reserve(info_.joints.size() * 3);
+
+    for (const auto & joint : info_.joints)
+    {
+      auto it = joint_index_.find(joint.name);
+      if (it == joint_index_.end())
+      {
+        continue;
+      }
+
+      auto & data = joints_[it->second];
+      interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION, &data.position_state);
+
+      if (data.has_velocity)
+      {
+        interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY, &data.velocity_state);
+      }
+
+      if (data.has_effort)
+      {
+        interfaces.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT, &data.effort_state);
+      }
     }
-    return sis;
+
+    return interfaces;
   }
 
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
-    std::vector<hardware_interface::CommandInterface> cis;
-    for (size_t i = 0; i < info_.joints.size(); ++i)
-      cis.emplace_back(info_.joints[i].name, hardware_interface::HW_IF_POSITION, cmd_ptrs_[i]);
-    return cis;
+    std::vector<hardware_interface::CommandInterface> interfaces;
+    interfaces.reserve(info_.joints.size());
+
+    for (const auto & joint : info_.joints)
+    {
+      auto it = joint_index_.find(joint.name);
+      if (it == joint_index_.end())
+      {
+        continue;
+      }
+
+      interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
+        &joints_[it->second].position_command);
+    }
+
+    return interfaces;
   }
 
-  // ---------------- Read / Write --------------------------------------
   return_type read(const rclcpp::Time &, const rclcpp::Duration &) override
   {
-    // state already populated asynchronously by device callbacks
+    for (auto & actuator : actuators_)
+    {
+      if (actuator.state_ptr)
+      {
+        actuator.position_state = *actuator.state_ptr;
+      }
+
+      if (actuator.velocity_ptr)
+      {
+        actuator.velocity_state = *actuator.velocity_ptr;
+      }
+
+      if (actuator.effort_ptr)
+      {
+        actuator.effort_state = *actuator.effort_ptr;
+      }
+
+      actuator.position_transmission = actuator.position_state;
+      actuator.velocity_transmission = actuator.velocity_ptr ? actuator.velocity_state : 0.0;
+      actuator.effort_transmission = actuator.effort_ptr ? actuator.effort_state : 0.0;
+    }
+
+    for (auto & transmission : transmissions_)
+    {
+      transmission->actuator_to_joint();
+    }
+
+    for (auto & joint : joints_)
+    {
+      joint.position_state = joint.position_transmission;
+      if (joint.has_velocity)
+      {
+        joint.velocity_state = joint.velocity_transmission;
+      }
+      if (joint.has_effort)
+      {
+        joint.effort_state = joint.effort_transmission;
+      }
+    }
+
     return return_type::OK;
   }
 
   return_type write(const rclcpp::Time & now, const rclcpp::Duration &) override
   {
-    for (auto & dev : devs_) dev->process(now);
+    for (auto & joint : joints_)
+    {
+      joint.position_transmission = joint.position_command;
+      joint.velocity_transmission = 0.0;
+      joint.effort_transmission = 0.0;
+    }
+
+    for (auto & transmission : transmissions_)
+    {
+      transmission->joint_to_actuator();
+    }
+
+    for (auto & actuator : actuators_)
+    {
+      actuator.position_command = actuator.position_transmission;
+      actuator.velocity_command = actuator.velocity_transmission;
+      actuator.effort_command = actuator.effort_transmission;
+
+      if (actuator.command_ptr)
+      {
+        *actuator.command_ptr = actuator.position_command;
+      }
+    }
+
+    for (auto & dev : devs_)
+    {
+      dev->process(now);
+    }
+
     return return_type::OK;
   }
 
 private:
+  struct JointData
+  {
+    explicit JointData(std::string name_in)
+    : name(std::move(name_in))
+    {
+    }
+
+    std::string name;
+    double position_command{0.0};
+    double position_state{0.0};
+    double velocity_state{0.0};
+    double effort_state{0.0};
+    double position_transmission{0.0};
+    double velocity_transmission{0.0};
+    double effort_transmission{0.0};
+    std::string actuator_name;
+    bool has_velocity{false};
+    bool has_effort{false};
+  };
+
+  struct ActuatorData
+  {
+    explicit ActuatorData(std::string name_in)
+    : name(std::move(name_in))
+    {
+    }
+
+    std::string name;
+    double position_command{0.0};
+    double velocity_command{0.0};
+    double effort_command{0.0};
+    double position_state{0.0};
+    double velocity_state{0.0};
+    double effort_state{0.0};
+    double position_transmission{0.0};
+    double velocity_transmission{0.0};
+    double effort_transmission{0.0};
+    double * state_ptr{nullptr};
+    double * velocity_ptr{nullptr};
+    double * effort_ptr{nullptr};
+    double * command_ptr{nullptr};
+    bool configured{false};
+  };
+
+  JointData & get_joint(const std::string & name)
+  {
+    auto it = joint_index_.find(name);
+    if (it == joint_index_.end())
+    {
+      joints_.emplace_back(name);
+      joint_index_[name] = joints_.size() - 1;
+      return joints_.back();
+    }
+
+    return joints_[it->second];
+  }
+
+  ActuatorData & get_actuator(const std::string & name)
+  {
+    auto it = actuator_index_.find(name);
+    if (it == actuator_index_.end())
+    {
+      actuators_.emplace_back(name);
+      actuator_index_[name] = actuators_.size() - 1;
+      return actuators_.back();
+    }
+
+    return actuators_[it->second];
+  }
+
   std::shared_ptr<pluginlib::ClassLoader<CanDevice>> loader_;
   std::vector<std::shared_ptr<CanDevice>> devs_;
 
-  std::vector<double*> pos_ptrs_, vel_ptrs_, eff_ptrs_, cmd_ptrs_;
+  std::unordered_map<std::string, size_t> joint_index_;
+  std::unordered_map<std::string, size_t> actuator_index_;
+  std::vector<JointData> joints_;
+  std::vector<ActuatorData> actuators_;
+  std::vector<std::shared_ptr<transmission_interface::Transmission>> transmissions_;
+
+  std::vector<double *> pos_ptrs_;
+  std::vector<double *> vel_ptrs_;
+  std::vector<double *> eff_ptrs_;
+  std::vector<double *> cmd_ptrs_;
+
   rclcpp::Node::SharedPtr node_;
 };
 

--- a/src/mr2_devices_ak_servo/src/ak_servo_device.cpp
+++ b/src/mr2_devices_ak_servo/src/ak_servo_device.cpp
@@ -14,7 +14,6 @@ public:
   {
     node_   = node;
     id_     = std::stoi(ji.parameters.at("motor_id"));
-    gear_   = std::stod(ji.parameters.at("gear_ratio"));
     iface_  = ji.parameters.at("can_iface");        // e.g. "can0"
 
     // obtain bus & store shared_ptr
@@ -35,7 +34,7 @@ public:
     struct can_frame fr{};
     fr.can_id  = (0x00000400 | id_) | CAN_EFF_FLAG;   // Control-ID 4
     fr.can_dlc = 8;
-    int32_t p  = std::lround(cmd_[0] * 180.0 / M_PI * gear_ * 1e4);
+    int32_t p  = std::lround(cmd_[0] * 180.0 / M_PI * 1e4);
     fr.data[0] = (p >> 24) & 0xFF;
     fr.data[1] = (p >> 16) & 0xFF;
     fr.data[2] = (p >>  8) & 0xFF;
@@ -64,8 +63,8 @@ private:
     int16_t v10 = (f.data[2] << 8) | f.data[3];
     int16_t c01 = (f.data[4] << 8) | f.data[5];
 
-    pos_[0] = (p10 / 10.0) / gear_ * (M_PI / 180.0);
-    vel_[0] = (v10 * 10.0) / gear_ * (M_PI / 30.0);   // rpm→rad/s
+    pos_[0] = (p10 / 10.0) * (M_PI / 180.0);
+    vel_[0] = (v10 * 10.0) * (M_PI / 30.0);   // rpm→rad/s
     eff_[0] = c01 / 100.0;                            // amps
   }
 
@@ -74,7 +73,6 @@ private:
   std::shared_ptr<CanBusManager> bus_;
   std::string iface_;
   int    id_{0};
-  double gear_{1.0};
 
   std::vector<double> pos_, vel_, eff_, cmd_;
 };

--- a/src/mr2_launch/launch/sim.launch.py
+++ b/src/mr2_launch/launch/sim.launch.py
@@ -24,6 +24,11 @@ def generate_launch_description():
         default_value="false",
         description="Run without GUI components",
     )
+    can_iface_arg = DeclareLaunchArgument(
+        "can_iface",
+        default_value="can0",
+        description="CAN interface used by the AK servo hardware",
+    )
 
     # ─── Nodes / Includes ────────────────────────────────────────────────────────
     use_sim_time = SetParameter(name="use_sim_time", value=True)
@@ -42,7 +47,8 @@ def generate_launch_description():
             )
         ),
         launch_arguments={
-            "headless": LaunchConfiguration("headless")
+            "headless": LaunchConfiguration("headless"),
+            "can_iface": LaunchConfiguration("can_iface"),
         }.items(),
     )
 
@@ -79,6 +85,7 @@ def generate_launch_description():
     return LaunchDescription([
         rviz_arg,
         headless_arg,
+        can_iface_arg,
         use_sim_time,
         rover_launch,
         pc2_to_heightmap,

--- a/src/mr2_rover_description/launch/rover.launch.py
+++ b/src/mr2_rover_description/launch/rover.launch.py
@@ -20,7 +20,21 @@ def generate_launch_description():
     bridge_yaml = PathJoinSubstitution([desc_pkg, "config", "gz_bridge.yaml"])
     world_file = PathJoinSubstitution([desc_pkg, "worlds", "world.sdf"])
 
-    robot_description = {"robot_description": Command(["xacro ", xacro_file])}
+    can_iface = LaunchConfiguration("can_iface")
+    can_iface_arg = DeclareLaunchArgument(
+        "can_iface",
+        default_value="can0",
+        description="CAN interface used by the AK servo hardware",
+    )
+
+    robot_description = {
+        "robot_description": Command([
+            "xacro ",
+            xacro_file,
+            " can_iface:=",
+            can_iface,
+        ])
+    }
 
     headless = LaunchConfiguration("headless")
     headless_arg = DeclareLaunchArgument(
@@ -105,6 +119,7 @@ def generate_launch_description():
     return LaunchDescription(
         [
             headless_arg,
+            can_iface_arg,
             gz_sim,
             gz_sim_headless,
             rsp,

--- a/src/mr2_rover_description/launch/single_joint.launch.py
+++ b/src/mr2_rover_description/launch/single_joint.launch.py
@@ -1,6 +1,6 @@
 from launch import LaunchDescription
-from launch.actions import TimerAction
-from launch.substitutions import Command, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, TimerAction
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -18,7 +18,21 @@ def generate_launch_description():
         "single_joint_controllers.yaml",
     ])
 
-    robot_description = {"robot_description": Command(["xacro ", xacro_file])}
+    can_iface = LaunchConfiguration("can_iface")
+    can_iface_arg = DeclareLaunchArgument(
+        "can_iface",
+        default_value="can0",
+        description="CAN interface used by the AK servo hardware",
+    )
+
+    robot_description = {
+        "robot_description": Command([
+            "xacro ",
+            xacro_file,
+            " can_iface:=",
+            can_iface,
+        ])
+    }
 
     rsp = Node(
         package="robot_state_publisher",
@@ -48,6 +62,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            can_iface_arg,
             rsp,
             ros2_control_node,
             TimerAction(period=2.0, actions=[jsb_spawner]),

--- a/src/mr2_rover_description/ros2_control/manipulator_ak_can.ros2_control.xacro
+++ b/src/mr2_rover_description/ros2_control/manipulator_ak_can.ros2_control.xacro
@@ -1,0 +1,158 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="manipulator_ak_can_ros2_control" params="name can_iface:=can0">
+
+    <ros2_control name="${name}" type="system">
+      <hardware>
+        <plugin>mr2_can_hardware_interface/CanHW</plugin>
+      </hardware>
+
+      <joint name="arm_j1">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor1</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">1</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <joint name="arm_j2">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor2</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">2</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <joint name="arm_j3">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor3</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">3</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <joint name="arm_j4">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor4</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">4</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <joint name="arm_j5">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor5</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">5</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <joint name="arm_j6">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+        <param name="actuator">motor6</param>
+        <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
+        <param name="motor_id">6</param>
+        <param name="can_iface">${can_iface}</param>
+      </joint>
+
+      <transmission name="arm_j1_transmission">
+        <plugin>transmission_interface/SimpleTransmission</plugin>
+        <actuator name="motor1" role="motor1">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </actuator>
+        <joint name="arm_j1" role="arm_j1">
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </joint>
+      </transmission>
+
+      <transmission name="arm_j2_j3_transmission">
+        <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+        <actuator name="motor2" role="motor2">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </actuator>
+        <actuator name="motor3" role="motor3">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </actuator>
+        <joint name="arm_j2" role="arm_j2">
+          <mechanical_reduction>50.0</mechanical_reduction>
+          <offset>0.0</offset>
+        </joint>
+        <joint name="arm_j3" role="arm_j3">
+          <mechanical_reduction>50.0</mechanical_reduction>
+          <offset>0.0</offset>
+        </joint>
+      </transmission>
+
+      <transmission name="arm_j4_transmission">
+        <plugin>transmission_interface/SimpleTransmission</plugin>
+        <actuator name="motor4" role="motor4">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </actuator>
+        <joint name="arm_j4" role="arm_j4">
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </joint>
+      </transmission>
+
+      <transmission name="arm_j5_transmission">
+        <plugin>transmission_interface/SimpleTransmission</plugin>
+        <actuator name="motor5" role="motor5">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </actuator>
+        <joint name="arm_j5" role="arm_j5">
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </joint>
+      </transmission>
+
+      <transmission name="arm_j6_transmission">
+        <plugin>transmission_interface/SimpleTransmission</plugin>
+        <actuator name="motor6" role="motor6">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </actuator>
+        <joint name="arm_j6" role="arm_j6">
+          <mechanical_reduction>1.0</mechanical_reduction>
+        </joint>
+      </transmission>
+
+    </ros2_control>
+  </xacro:macro>
+
+</robot>

--- a/src/mr2_rover_description/setup.py
+++ b/src/mr2_rover_description/setup.py
@@ -11,6 +11,7 @@ setup(
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         (f"share/{package_name}/launch", glob("launch/*.launch.py")),
         (f"share/{package_name}/urdf", glob("urdf/*.xacro")),
+        (f"share/{package_name}/ros2_control", glob("ros2_control/*.xacro")),
         (f"share/{package_name}/config", glob("config/*")),
         (f"share/{package_name}/worlds", glob("worlds/*")),
         (f"share/{package_name}", ["package.xml"]),

--- a/src/mr2_rover_description/urdf/manipulator_ak_can.urdf.xacro
+++ b/src/mr2_rover_description/urdf/manipulator_ak_can.urdf.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="mr2_manipulator_ak_can">
+  <xacro:arg name="can_iface" default="can0"/>
+
+  <link name="base_link"/>
+
+  <xacro:include filename="manipulator.xacro"/>
+  <xacro:include filename="$(find mr2_rover_description)/ros2_control/manipulator_ak_can.ros2_control.xacro"/>
+
+  <xacro:manipulator/>
+
+  <xacro:manipulator_ak_can_ros2_control name="ArmCanSystem" can_iface="$(arg can_iface)"/>
+</robot>

--- a/src/mr2_rover_description/urdf/rover.urdf.xacro
+++ b/src/mr2_rover_description/urdf/rover.urdf.xacro
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rover">
+  <xacro:arg name="can_iface" default="can0"/>
   <!-- Include component macros -->
   <xacro:include filename="$(find mr2_rover_description)/urdf/rover_base.xacro"/>
   <xacro:include filename="$(find mr2_rover_description)/urdf/swerve_module.xacro"/>

--- a/src/mr2_rover_description/urdf/single_joint.urdf.xacro
+++ b/src/mr2_rover_description/urdf/single_joint.urdf.xacro
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="single_joint">
+  <xacro:arg name="can_iface" default="can0"/>
+
   <link name="base_link"/>
   <link name="link1"/>
 
@@ -21,11 +23,24 @@
       <state_interface name="position"/>
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
+      <param name="actuator">motor4</param>
       <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
       <param name="motor_id">4</param>
-      <param name="gear_ratio">1.0</param>
-      <param name="can_iface">can0</param>
+      <param name="can_iface">$(arg can_iface)</param>
     </joint>
+
+    <transmission name="joint1_transmission">
+      <plugin>transmission_interface/SimpleTransmission</plugin>
+      <actuator name="motor4" role="motor4">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </actuator>
+      <joint name="joint1" role="joint1">
+        <mechanical_reduction>1.0</mechanical_reduction>
+      </joint>
+    </transmission>
   </ros2_control>
 </robot>
 


### PR DESCRIPTION
## Summary
- extend the CAN hardware interface to wire velocity and effort handles through transmissions and copy data between actuators and joints
- expose velocity and effort interfaces in the manipulator and single-joint ros2_control descriptions so those states are available to controllers

## Testing
- not run (colcon unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deacf81f9483259e6314e8a3fb4fb9