### PR TITLE
Support velocity and effort feedback for AK servos

### DIFF
--- a/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_manager.hpp
+++ b/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_manager.hpp
@@ -3,18 +3,19 @@
 // =============================================================
 #pragma once
 
+#include <fcntl.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
-#include <poll.h>
 #include <net/if.h>
+#include <poll.h>
 #include <sys/ioctl.h>
-#include <fcntl.h>
 #include <unistd.h>
 
 #include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -28,28 +29,30 @@
  *  * register_listener() adds (id,mask) filter + callback
  *  * enqueue_tx()   queues frame and wakes thread via pipe
  */
-class CanBusManager : public std::enable_shared_from_this<CanBusManager>
-{
+class CanBusManager : public std::enable_shared_from_this<CanBusManager> {
 public:
-  using RxCallback = std::function<void(const struct can_frame&)>;
+  using RxCallback = std::function<void(const struct can_frame &)>;
 
-  CanBusManager()  = default;
+  CanBusManager() = default;
   ~CanBusManager() { stop(); }
 
-  CanBusManager(const CanBusManager&)            = delete;
-  CanBusManager& operator=(const CanBusManager&) = delete;
+  CanBusManager(const CanBusManager &) = delete;
+  CanBusManager &operator=(const CanBusManager &) = delete;
 
-  bool start(const std::string& iface, int bitrate);
+  bool start(const std::string &iface, int bitrate);
   void stop();
 
   // device‑side API
   void register_listener(uint32_t id, uint32_t mask, RxCallback cb);
-  void enqueue_tx(const struct can_frame& fr);
+  void enqueue_tx(const struct can_frame &fr);
 
   uint64_t dropped_tx() const noexcept { return dropped_tx_; }
 
 private:
-  struct Listener { uint32_t id, mask; RxCallback cb; };
+  struct Listener {
+    uint32_t id, mask;
+    RxCallback cb;
+  };
 
   // worker helpers
   void io_loop_();
@@ -57,90 +60,134 @@ private:
   void rx_once_();
 
   // members
-  int  fd_{-1};
-  int  wake_pipe_[2]{-1, -1};
-  std::thread      io_th_;
+  int fd_{-1};
+  int wake_pipe_[2]{-1, -1};
+  std::thread io_th_;
   std::atomic_bool running_{false};
 
-  std::string iface_{}; int bitrate_{0};
+  std::string iface_{};
+  int bitrate_{0};
 
   std::vector<Listener> listeners_;
-  std::mutex            lst_mtx_;
+  std::mutex lst_mtx_;
 
   std::queue<struct can_frame> tx_q_;
-  std::mutex                   tx_mtx_;
-  std::atomic_uint64_t         dropped_tx_{0};
+  std::mutex tx_mtx_;
+  std::atomic_uint64_t dropped_tx_{0};
 };
 
 // -------------- Inline implementation ----------------
-inline bool CanBusManager::start(const std::string& iface, int bitrate)
-{
-  if (running_) return true;
-  iface_ = iface; bitrate_ = bitrate;
+inline bool CanBusManager::start(const std::string &iface, int bitrate) {
+  if (running_)
+    return true;
+  iface_ = iface;
+  bitrate_ = bitrate;
 
   fd_ = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
-  if (fd_ < 0) { perror("socket"); return false; }
+  if (fd_ < 0) {
+    perror("socket");
+    return false;
+  }
 
   int flags = fcntl(fd_, F_GETFL, 0);
   fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
 
-  struct ifreq ifr{}; std::strncpy(ifr.ifr_name, iface.c_str(), IFNAMSIZ-1);
-  struct sockaddr_can addr{};
-  if (ioctl(fd_, SIOCGIFINDEX, &ifr) < 0) { perror("SIOCGIFINDEX"); goto err; }
-  addr.can_family=AF_CAN; addr.can_ifindex=ifr.ifr_ifindex;
-  if (bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) { perror("bind"); goto err; }
+  struct ifreq ifr {};
+  std::strncpy(ifr.ifr_name, iface.c_str(), IFNAMSIZ - 1);
+  struct sockaddr_can addr {};
+  if (ioctl(fd_, SIOCGIFINDEX, &ifr) < 0) {
+    perror("SIOCGIFINDEX");
+    goto err;
+  }
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+  if (bind(fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+    perror("bind");
+    goto err;
+  }
 
-  if (pipe2(wake_pipe_, O_NONBLOCK) < 0) { perror("pipe2"); goto err; }
+  if (pipe2(wake_pipe_, O_NONBLOCK) < 0) {
+    perror("pipe2");
+    goto err;
+  }
 
   running_ = true;
-  io_th_   = std::thread(&CanBusManager::io_loop_, this);
+  io_th_ = std::thread(&CanBusManager::io_loop_, this);
   return true;
 err:
-  if (fd_>=0) ::close(fd_);
-  fd_=-1; return false;
+  if (fd_ >= 0)
+    ::close(fd_);
+  fd_ = -1;
+  return false;
 }
 
-inline void CanBusManager::stop()
-{
+inline void CanBusManager::stop() {
   running_ = false;
-  if (io_th_.joinable()) io_th_.join();
-  if (fd_>=0) { ::close(fd_); fd_=-1; }
-  if (wake_pipe_[0]>=0) { ::close(wake_pipe_[0]); ::close(wake_pipe_[1]); wake_pipe_[0]=wake_pipe_[1]=-1; }
-}
-
-inline void CanBusManager::register_listener(uint32_t id, uint32_t mask, RxCallback cb)
-{ std::lock_guard<std::mutex> lk(lst_mtx_); listeners_.push_back({id,mask,std::move(cb)}); }
-
-inline void CanBusManager::enqueue_tx(const struct can_frame& fr)
-{
-  { std::lock_guard<std::mutex> lk(tx_mtx_); tx_q_.push(fr); }
-  char one=1; write(wake_pipe_[1], &one, 1);
-}
-
-inline void CanBusManager::io_loop_()
-{
-  struct pollfd pfds[2]{{fd_,POLLIN,0},{wake_pipe_[0],POLLIN,0}};
-  while(running_){
-    flush_tx_();
-    int n=poll(pfds,2,10);
-    if(n<=0) continue;
-    if(pfds[0].revents&POLLIN) rx_once_();
-    if(pfds[1].revents&POLLIN){ char buf[16]; read(wake_pipe_[0],buf,sizeof(buf)); }
+  if (io_th_.joinable())
+    io_th_.join();
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+  if (wake_pipe_[0] >= 0) {
+    ::close(wake_pipe_[0]);
+    ::close(wake_pipe_[1]);
+    wake_pipe_[0] = wake_pipe_[1] = -1;
   }
 }
 
-inline void CanBusManager::flush_tx_()
-{
-  struct can_frame fr{};
-  for(;;){
-    { std::lock_guard<std::mutex> lk(tx_mtx_); if(tx_q_.empty()) break; fr=tx_q_.front(); tx_q_.pop(); }
-    if(::write(fd_,&fr,CAN_MTU)!=CAN_MTU) dropped_tx_++; }
-}
-
-inline void CanBusManager::rx_once_()
-{
-  struct can_frame fr{}; if(::read(fd_,&fr,CAN_MTU)!=CAN_MTU) return;
+inline void CanBusManager::register_listener(uint32_t id, uint32_t mask,
+                                             RxCallback cb) {
   std::lock_guard<std::mutex> lk(lst_mtx_);
-  for(const auto &l: listeners_) if((fr.can_id&l.mask)==l.id) l.cb(fr);
+  listeners_.push_back({id, mask, std::move(cb)});
 }
 
+inline void CanBusManager::enqueue_tx(const struct can_frame &fr) {
+  {
+    std::lock_guard<std::mutex> lk(tx_mtx_);
+    tx_q_.push(fr);
+  }
+  char one = 1;
+  write(wake_pipe_[1], &one, 1);
+}
+
+inline void CanBusManager::io_loop_() {
+  struct pollfd pfds[2]{{fd_, POLLIN, 0}, {wake_pipe_[0], POLLIN, 0}};
+  while (running_) {
+    flush_tx_();
+    int n = poll(pfds, 2, 10);
+    if (n <= 0)
+      continue;
+    if (pfds[0].revents & POLLIN)
+      rx_once_();
+    if (pfds[1].revents & POLLIN) {
+      char buf[16];
+      read(wake_pipe_[0], buf, sizeof(buf));
+    }
+  }
+}
+
+inline void CanBusManager::flush_tx_() {
+  struct can_frame fr {};
+  for (;;) {
+    {
+      std::lock_guard<std::mutex> lk(tx_mtx_);
+      if (tx_q_.empty())
+        break;
+      fr = tx_q_.front();
+      tx_q_.pop();
+    }
+    if (::write(fd_, &fr, CAN_MTU) != CAN_MTU)
+      dropped_tx_++;
+  }
+}
+
+inline void CanBusManager::rx_once_() {
+  struct can_frame fr {};
+  if (::read(fd_, &fr, CAN_MTU) != CAN_MTU)
+    return;
+  std::lock_guard<std::mutex> lk(lst_mtx_);
+  for (const auto &l : listeners_)
+    if ((fr.can_id & l.mask) == l.id)
+      l.cb(fr);
+}

--- a/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_registry.hpp
+++ b/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_registry.hpp
@@ -3,31 +3,33 @@
 // =============================================================
 #pragma once
 
+#include "can_bus_manager.hpp"
 #include <memory>
 #include <mutex>
-#include <unordered_map>
 #include <string>
-#include "can_bus_manager.hpp"
+#include <unordered_map>
 
-class CanBusRegistry
-{
+class CanBusRegistry {
 public:
   /** Get or create manager for given interface name. */
-  static std::shared_ptr<CanBusManager> get(const std::string & iface,
-                                            int bitrate = 1'000'000)
-  {
+  static std::shared_ptr<CanBusManager> get(const std::string &iface,
+                                            int bitrate = 1'000'000) {
     std::lock_guard<std::mutex> lk(map_mtx_);
-    auto & weak = map_[iface];
-    auto sp     = weak.lock();
+    auto &weak = map_[iface];
+    auto sp = weak.lock();
     if (!sp) {
       sp = std::make_shared<CanBusManager>();
-      if (!sp->start(iface, bitrate)) { map_.erase(iface); return {}; }
+      if (!sp->start(iface, bitrate)) {
+        map_.erase(iface);
+        return {};
+      }
       weak = sp;
     }
     return sp;
   }
+
 private:
-  static inline std::unordered_map<std::string, std::weak_ptr<CanBusManager>> map_{};
+  static inline std::unordered_map<std::string, std::weak_ptr<CanBusManager>>
+      map_{};
   static inline std::mutex map_mtx_;
 };
-

--- a/src/mr2_can_bus_core/include/mr2_can_bus_core/can_device.hpp
+++ b/src/mr2_can_bus_core/include/mr2_can_bus_core/can_device.hpp
@@ -1,15 +1,14 @@
 #pragma once
-#include <linux/can.h>
-#include <vector>
-#include <memory>
-#include <rclcpp/time.hpp>  
-#include <rclcpp/node.hpp>  
-#include <hardware_interface/types/hardware_interface_type_values.hpp>  
-#include <hardware_interface/component_parser.hpp>
 #include "can_bus_registry.hpp"
+#include <hardware_interface/component_parser.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <linux/can.h>
+#include <memory>
+#include <rclcpp/node.hpp>
+#include <rclcpp/time.hpp>
+#include <vector>
 
-class CanDevice
-{
+class CanDevice {
 public:
   virtual ~CanDevice() = default;
 
@@ -17,36 +16,37 @@ public:
    * Configure the device with parameters taken from the joint / component
    * description and the ROS node that owns it.
    */
-  virtual void configure(const hardware_interface::ComponentInfo & info,
-                         rclcpp::Node * node) = 0;
+  virtual void configure(const hardware_interface::ComponentInfo &info,
+                         rclcpp::Node *node) = 0;
 
   /**
    * Called once per controller update cycle – typically send a CAN command.
    */
-  virtual void process(const rclcpp::Time & now) = 0;
+  virtual void process(const rclcpp::Time &now) = 0;
 
   /**
    * Export state arrays (pointers) so the ros2_control SystemInterface can
    * wire them into the joint_state interfaces.
    */
-  virtual void export_state(std::vector<double*> & pos,
-                            std::vector<double*> & vel,
-                            std::vector<double*> & eff) = 0;
+  virtual void export_state(std::vector<double *> &pos,
+                            std::vector<double *> &vel,
+                            std::vector<double *> &eff) = 0;
 
   /**
    * Export command array pointers (usually position commands).
    */
-  virtual void export_command(std::vector<double*> & cmd) = 0;
+  virtual void export_command(std::vector<double *> &cmd) = 0;
 
 protected:
   /** Shorthand for sending on the appropriate bus */
-  void send(const struct can_frame & f,
-            const std::shared_ptr<CanBusManager> & bus)
-  { bus->enqueue_tx(f); }
+  void send(const struct can_frame &f,
+            const std::shared_ptr<CanBusManager> &bus) {
+    bus->enqueue_tx(f);
+  }
 
   /** Register a listener for this device on its bus */
-  void add_filter(const std::shared_ptr<CanBusManager> & bus,
-                  uint32_t id, uint32_t mask,
-                  CanBusManager::RxCallback cb)
-  { bus->register_listener(id, mask, std::move(cb)); }
+  void add_filter(const std::shared_ptr<CanBusManager> &bus, uint32_t id,
+                  uint32_t mask, CanBusManager::RxCallback cb) {
+    bus->register_listener(id, mask, std::move(cb));
+  }
 };

--- a/src/mr2_can_hardware_interface/src/can_hw.cpp
+++ b/src/mr2_can_hardware_interface/src/can_hw.cpp
@@ -64,6 +64,10 @@ public:
 
     for (const auto & joint : info_.joints)
     {
+      auto & joint_data = get_joint(joint.name);
+      joint_data.has_velocity_state = false;
+      joint_data.has_effort_state = false;
+
       if (joint.command_interfaces.size() != 1 ||
           joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
       {
@@ -72,15 +76,36 @@ public:
         return CallbackReturn::ERROR;
       }
 
-      if (joint.state_interfaces.size() != 1 ||
-          joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+      bool has_position_state = false;
+      for (const auto & state_iface : joint.state_interfaces)
       {
-        RCLCPP_ERROR(node_->get_logger(), "Joint %s must expose a single position state interface",
-          joint.name.c_str());
-        return CallbackReturn::ERROR;
+        if (state_iface.name == hardware_interface::HW_IF_POSITION)
+        {
+          has_position_state = true;
+        }
+        else if (state_iface.name == hardware_interface::HW_IF_VELOCITY)
+        {
+          joint_data.has_velocity_state = true;
+        }
+        else if (state_iface.name == hardware_interface::HW_IF_EFFORT)
+        {
+          joint_data.has_effort_state = true;
+        }
+        else
+        {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Joint %s exposes unsupported state interface '%s'",
+            joint.name.c_str(), state_iface.name.c_str());
+          return CallbackReturn::ERROR;
+        }
       }
 
-      auto & joint_data = get_joint(joint.name);
+      if (!has_position_state)
+      {
+        RCLCPP_ERROR(node_->get_logger(),
+          "Joint %s must expose a position state interface", joint.name.c_str());
+        return CallbackReturn::ERROR;
+      }
 
       const auto plugin_it = joint.parameters.find("device_plugin");
       if (plugin_it == joint.parameters.end())
@@ -182,17 +207,62 @@ public:
       }
 
       std::vector<transmission_interface::JointHandle> joint_handles;
-      joint_handles.reserve(transmission_info.joints.size());
+      joint_handles.reserve(transmission_info.joints.size() * 3);
 
       for (const auto & joint_info : transmission_info.joints)
       {
         auto & joint = get_joint(joint_info.name);
-        joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_POSITION,
-          &joint.transmission_passthrough);
+
+        bool position_added = false;
+        bool velocity_added = false;
+        bool effort_added = false;
+
+        auto add_joint_handle = [&](const std::string & interface) {
+          if (interface == hardware_interface::HW_IF_POSITION && !position_added)
+          {
+            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_POSITION,
+              &joint.transmission_passthrough);
+            position_added = true;
+          }
+          else if (interface == hardware_interface::HW_IF_VELOCITY && !velocity_added)
+          {
+            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_VELOCITY,
+              &joint.transmission_velocity);
+            velocity_added = true;
+          }
+          else if (interface == hardware_interface::HW_IF_EFFORT && !effort_added)
+          {
+            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_EFFORT,
+              &joint.transmission_effort);
+            effort_added = true;
+          }
+        };
+
+        add_joint_handle(hardware_interface::HW_IF_POSITION);
+
+        if (joint.has_velocity_state)
+        {
+          add_joint_handle(hardware_interface::HW_IF_VELOCITY);
+        }
+
+        if (joint.has_effort_state)
+        {
+          add_joint_handle(hardware_interface::HW_IF_EFFORT);
+        }
+
+        for (const auto & cmd_iface : joint_info.command_interfaces)
+        {
+          add_joint_handle(cmd_iface);
+        }
+
+        for (const auto & state_iface : joint_info.state_interfaces)
+        {
+          add_joint_handle(state_iface);
+        }
       }
 
       std::vector<transmission_interface::ActuatorHandle> actuator_handles;
-      actuator_handles.reserve(transmission_info.actuators.size());
+      actuator_handles.reserve(transmission_info.actuators.size() * 3);
 
       for (const auto & actuator_info : transmission_info.actuators)
       {
@@ -206,8 +276,52 @@ public:
           return CallbackReturn::ERROR;
         }
 
-        actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_POSITION,
-          &actuator.transmission_passthrough);
+        bool position_added = false;
+        bool velocity_added = false;
+        bool effort_added = false;
+
+        auto add_actuator_handle = [&](const std::string & interface) {
+          if (interface == hardware_interface::HW_IF_POSITION && !position_added)
+          {
+            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_POSITION,
+              &actuator.transmission_passthrough);
+            position_added = true;
+          }
+          else if (interface == hardware_interface::HW_IF_VELOCITY && !velocity_added)
+          {
+            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_VELOCITY,
+              &actuator.transmission_velocity);
+            velocity_added = true;
+          }
+          else if (interface == hardware_interface::HW_IF_EFFORT && !effort_added)
+          {
+            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_EFFORT,
+              &actuator.transmission_effort);
+            effort_added = true;
+          }
+        };
+
+        add_actuator_handle(hardware_interface::HW_IF_POSITION);
+
+        if (actuator.velocity_ptr)
+        {
+          add_actuator_handle(hardware_interface::HW_IF_VELOCITY);
+        }
+
+        if (actuator.effort_ptr)
+        {
+          add_actuator_handle(hardware_interface::HW_IF_EFFORT);
+        }
+
+        for (const auto & cmd_iface : actuator_info.command_interfaces)
+        {
+          add_actuator_handle(cmd_iface);
+        }
+
+        for (const auto & state_iface : actuator_info.state_interfaces)
+        {
+          add_actuator_handle(state_iface);
+        }
       }
 
       try
@@ -239,7 +353,7 @@ public:
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     std::vector<hardware_interface::StateInterface> interfaces;
-    interfaces.reserve(info_.joints.size());
+    interfaces.reserve(info_.joints.size() * 3);
 
     for (const auto & joint : info_.joints)
     {
@@ -249,8 +363,22 @@ public:
         continue;
       }
 
+      auto & joint_data = joints_[it->second];
+
       interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
-        &joints_[it->second].state);
+        &joint_data.state);
+
+      if (joint_data.has_velocity_state)
+      {
+        interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY,
+          &joint_data.velocity);
+      }
+
+      if (joint_data.has_effort_state)
+      {
+        interfaces.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT,
+          &joint_data.effort);
+      }
     }
 
     return interfaces;
@@ -284,8 +412,32 @@ public:
       {
         actuator.state = *actuator.state_ptr;
       }
+      else
+      {
+        actuator.state = 0.0;
+      }
+
+      if (actuator.velocity_ptr)
+      {
+        actuator.velocity = *actuator.velocity_ptr;
+      }
+      else
+      {
+        actuator.velocity = 0.0;
+      }
+
+      if (actuator.effort_ptr)
+      {
+        actuator.effort = *actuator.effort_ptr;
+      }
+      else
+      {
+        actuator.effort = 0.0;
+      }
 
       actuator.transmission_passthrough = actuator.state;
+      actuator.transmission_velocity = actuator.velocity;
+      actuator.transmission_effort = actuator.effort;
     }
 
     for (auto & transmission : transmissions_)
@@ -296,6 +448,8 @@ public:
     for (auto & joint : joints_)
     {
       joint.state = joint.transmission_passthrough;
+      joint.velocity = joint.transmission_velocity;
+      joint.effort = joint.transmission_effort;
     }
 
     return return_type::OK;
@@ -306,6 +460,8 @@ public:
     for (auto & joint : joints_)
     {
       joint.transmission_passthrough = joint.command;
+      joint.transmission_velocity = 0.0;
+      joint.transmission_effort = 0.0;
     }
 
     for (auto & transmission : transmissions_)
@@ -342,8 +498,14 @@ private:
     std::string name;
     double command{0.0};
     double state{0.0};
+    double velocity{0.0};
+    double effort{0.0};
     double transmission_passthrough{0.0};
+    double transmission_velocity{0.0};
+    double transmission_effort{0.0};
     std::string actuator_name;
+    bool has_velocity_state{false};
+    bool has_effort_state{false};
   };
 
   struct ActuatorData
@@ -356,7 +518,11 @@ private:
     std::string name;
     double command{0.0};
     double state{0.0};
+    double velocity{0.0};
+    double effort{0.0};
     double transmission_passthrough{0.0};
+    double transmission_velocity{0.0};
+    double transmission_effort{0.0};
     double * state_ptr{nullptr};
     double * velocity_ptr{nullptr};
     double * effort_ptr{nullptr};

--- a/src/mr2_can_hardware_interface/src/can_hw.cpp
+++ b/src/mr2_can_hardware_interface/src/can_hw.cpp
@@ -5,10 +5,10 @@
 #include <utility>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "pluginlib/class_loader.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 #include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
 #include "transmission_interface/simple_transmission_loader.hpp"
@@ -20,30 +20,25 @@
 using hardware_interface::CallbackReturn;
 using hardware_interface::return_type;
 
-namespace mr2_can_hardware_interface
-{
+namespace mr2_can_hardware_interface {
 
-class CanHW : public hardware_interface::SystemInterface
-{
+class CanHW : public hardware_interface::SystemInterface {
 public:
   CanHW() = default;
   ~CanHW() override = default;
 
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override
-  {
-    if (SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
-    {
+  CallbackReturn
+  on_init(const hardware_interface::HardwareInfo &info) override {
+    if (SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
       return CallbackReturn::ERROR;
     }
 
     node_ = rclcpp::Node::make_shared("can_hw");
 
-    try
-    {
-      loader_ = std::make_shared<pluginlib::ClassLoader<CanDevice>>("mr2_can_bus_core", "CanDevice");
-    }
-    catch (const pluginlib::PluginlibException & ex)
-    {
+    try {
+      loader_ = std::make_shared<pluginlib::ClassLoader<CanDevice>>(
+          "mr2_can_bus_core", "CanDevice");
+    } catch (const pluginlib::PluginlibException &ex) {
       RCLCPP_ERROR(node_->get_logger(), "Pluginlib load error: %s", ex.what());
       return CallbackReturn::ERROR;
     }
@@ -62,87 +57,74 @@ public:
     transmission_interface::SimpleTransmissionLoader simple_loader;
     transmission_interface::FourBarLinkageTransmissionLoader four_bar_loader;
 
-    for (const auto & joint : info_.joints)
-    {
-      auto & joint_data = get_joint(joint.name);
+    for (const auto &joint : info_.joints) {
+      auto &joint_data = get_joint(joint.name);
       joint_data.has_velocity_state = false;
       joint_data.has_effort_state = false;
 
       if (joint.command_interfaces.size() != 1 ||
-          joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
-      {
-        RCLCPP_ERROR(node_->get_logger(), "Joint %s must expose a single position command interface",
-          joint.name.c_str());
+          joint.command_interfaces[0].name !=
+              hardware_interface::HW_IF_POSITION) {
+        RCLCPP_ERROR(node_->get_logger(),
+                     "Joint %s must expose a single position command interface",
+                     joint.name.c_str());
         return CallbackReturn::ERROR;
       }
 
       bool has_position_state = false;
-      for (const auto & state_iface : joint.state_interfaces)
-      {
-        if (state_iface.name == hardware_interface::HW_IF_POSITION)
-        {
+      for (const auto &state_iface : joint.state_interfaces) {
+        if (state_iface.name == hardware_interface::HW_IF_POSITION) {
           has_position_state = true;
-        }
-        else if (state_iface.name == hardware_interface::HW_IF_VELOCITY)
-        {
+        } else if (state_iface.name == hardware_interface::HW_IF_VELOCITY) {
           joint_data.has_velocity_state = true;
-        }
-        else if (state_iface.name == hardware_interface::HW_IF_EFFORT)
-        {
+        } else if (state_iface.name == hardware_interface::HW_IF_EFFORT) {
           joint_data.has_effort_state = true;
-        }
-        else
-        {
+        } else {
           RCLCPP_ERROR(node_->get_logger(),
-            "Joint %s exposes unsupported state interface '%s'",
-            joint.name.c_str(), state_iface.name.c_str());
+                       "Joint %s exposes unsupported state interface '%s'",
+                       joint.name.c_str(), state_iface.name.c_str());
           return CallbackReturn::ERROR;
         }
       }
 
-      if (!has_position_state)
-      {
+      if (!has_position_state) {
         RCLCPP_ERROR(node_->get_logger(),
-          "Joint %s must expose a position state interface", joint.name.c_str());
+                     "Joint %s must expose a position state interface",
+                     joint.name.c_str());
         return CallbackReturn::ERROR;
       }
 
       const auto plugin_it = joint.parameters.find("device_plugin");
-      if (plugin_it == joint.parameters.end())
-      {
+      if (plugin_it == joint.parameters.end()) {
         RCLCPP_ERROR(node_->get_logger(),
-          "Joint %s missing <param name=\"device_plugin\">", joint.name.c_str());
+                     "Joint %s missing <param name=\"device_plugin\">",
+                     joint.name.c_str());
         return CallbackReturn::ERROR;
       }
 
       const auto actuator_it = joint.parameters.find("actuator");
-      joint_data.actuator_name =
-        actuator_it != joint.parameters.end() ? actuator_it->second : joint.name;
+      joint_data.actuator_name = actuator_it != joint.parameters.end()
+                                     ? actuator_it->second
+                                     : joint.name;
 
-      auto & actuator = get_actuator(joint_data.actuator_name);
+      auto &actuator = get_actuator(joint_data.actuator_name);
 
-      if (!actuator.configured)
-      {
+      if (!actuator.configured) {
         std::shared_ptr<CanDevice> dev;
-        try
-        {
+        try {
           dev = loader_->createSharedInstance(plugin_it->second);
-        }
-        catch (const pluginlib::PluginlibException & ex)
-        {
-          RCLCPP_ERROR(node_->get_logger(), "Failed to load device plugin %s: %s",
-            plugin_it->second.c_str(), ex.what());
+        } catch (const pluginlib::PluginlibException &ex) {
+          RCLCPP_ERROR(node_->get_logger(),
+                       "Failed to load device plugin %s: %s",
+                       plugin_it->second.c_str(), ex.what());
           return CallbackReturn::ERROR;
         }
 
-        try
-        {
+        try {
           dev->configure(joint, node_.get());
-        }
-        catch (const std::exception & ex)
-        {
+        } catch (const std::exception &ex) {
           RCLCPP_ERROR(node_->get_logger(), "Device %s configure() threw: %s",
-            joint.name.c_str(), ex.what());
+                       joint.name.c_str(), ex.what());
           return CallbackReturn::ERROR;
         }
 
@@ -154,16 +136,20 @@ public:
         dev->export_state(pos_ptrs_, vel_ptrs_, eff_ptrs_);
         dev->export_command(cmd_ptrs_);
 
-        actuator.state_ptr = pos_ptrs_.size() > pos_idx ? pos_ptrs_[pos_idx] : nullptr;
-        actuator.velocity_ptr = vel_ptrs_.size() > vel_idx ? vel_ptrs_[vel_idx] : nullptr;
-        actuator.effort_ptr = eff_ptrs_.size() > eff_idx ? eff_ptrs_[eff_idx] : nullptr;
-        actuator.command_ptr = cmd_ptrs_.size() > cmd_idx ? cmd_ptrs_[cmd_idx] : nullptr;
+        actuator.state_ptr =
+            pos_ptrs_.size() > pos_idx ? pos_ptrs_[pos_idx] : nullptr;
+        actuator.velocity_ptr =
+            vel_ptrs_.size() > vel_idx ? vel_ptrs_[vel_idx] : nullptr;
+        actuator.effort_ptr =
+            eff_ptrs_.size() > eff_idx ? eff_ptrs_[eff_idx] : nullptr;
+        actuator.command_ptr =
+            cmd_ptrs_.size() > cmd_idx ? cmd_ptrs_[cmd_idx] : nullptr;
 
-        if (!actuator.state_ptr || !actuator.command_ptr)
-        {
+        if (!actuator.state_ptr || !actuator.command_ptr) {
           RCLCPP_ERROR(node_->get_logger(),
-            "Device for actuator %s failed to export state/command interfaces",
-            actuator.name.c_str());
+                       "Device for actuator %s failed to export state/command "
+                       "interfaces",
+                       actuator.name.c_str());
           return CallbackReturn::ERROR;
         }
 
@@ -172,91 +158,83 @@ public:
       }
     }
 
-    for (const auto & transmission_info : info_.transmissions)
-    {
+    for (const auto &transmission_info : info_.transmissions) {
       std::shared_ptr<transmission_interface::Transmission> transmission;
-      try
-      {
-        if (transmission_info.type == "transmission_interface/SimpleTransmission")
-        {
+      try {
+        if (transmission_info.type ==
+            "transmission_interface/SimpleTransmission") {
           transmission = simple_loader.load(transmission_info);
-        }
-        else if (transmission_info.type == "transmission_interface/FourBarLinkageTransmission")
-        {
+        } else if (transmission_info.type ==
+                   "transmission_interface/FourBarLinkageTransmission") {
           transmission = four_bar_loader.load(transmission_info);
-        }
-        else
-        {
-          RCLCPP_ERROR(node_->get_logger(), "Unsupported transmission type '%s'",
-            transmission_info.type.c_str());
+        } else {
+          RCLCPP_ERROR(node_->get_logger(),
+                       "Unsupported transmission type '%s'",
+                       transmission_info.type.c_str());
           return CallbackReturn::ERROR;
         }
-      }
-      catch (const transmission_interface::TransmissionInterfaceException & ex)
-      {
-        RCLCPP_ERROR(node_->get_logger(), "Error while loading transmission '%s': %s",
-          transmission_info.name.c_str(), ex.what());
+      } catch (
+          const transmission_interface::TransmissionInterfaceException &ex) {
+        RCLCPP_ERROR(node_->get_logger(),
+                     "Error while loading transmission '%s': %s",
+                     transmission_info.name.c_str(), ex.what());
         return CallbackReturn::ERROR;
       }
 
-      if (!transmission)
-      {
+      if (!transmission) {
         RCLCPP_ERROR(node_->get_logger(),
-          "Loader returned null transmission for '%s'", transmission_info.name.c_str());
+                     "Loader returned null transmission for '%s'",
+                     transmission_info.name.c_str());
         return CallbackReturn::ERROR;
       }
 
       std::vector<transmission_interface::JointHandle> joint_handles;
       joint_handles.reserve(transmission_info.joints.size() * 3);
 
-      for (const auto & joint_info : transmission_info.joints)
-      {
-        auto & joint = get_joint(joint_info.name);
+      for (const auto &joint_info : transmission_info.joints) {
+        auto &joint = get_joint(joint_info.name);
 
         bool position_added = false;
         bool velocity_added = false;
         bool effort_added = false;
 
-        auto add_joint_handle = [&](const std::string & interface) {
-          if (interface == hardware_interface::HW_IF_POSITION && !position_added)
-          {
-            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_POSITION,
-              &joint.transmission_passthrough);
+        auto add_joint_handle = [&](const std::string &interface) {
+          if (interface == hardware_interface::HW_IF_POSITION &&
+              !position_added) {
+            joint_handles.emplace_back(joint_info.name,
+                                       hardware_interface::HW_IF_POSITION,
+                                       &joint.transmission_passthrough);
             position_added = true;
-          }
-          else if (interface == hardware_interface::HW_IF_VELOCITY && !velocity_added)
-          {
-            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_VELOCITY,
-              &joint.transmission_velocity);
+          } else if (interface == hardware_interface::HW_IF_VELOCITY &&
+                     !velocity_added) {
+            joint_handles.emplace_back(joint_info.name,
+                                       hardware_interface::HW_IF_VELOCITY,
+                                       &joint.transmission_velocity);
             velocity_added = true;
-          }
-          else if (interface == hardware_interface::HW_IF_EFFORT && !effort_added)
-          {
-            joint_handles.emplace_back(joint_info.name, hardware_interface::HW_IF_EFFORT,
-              &joint.transmission_effort);
+          } else if (interface == hardware_interface::HW_IF_EFFORT &&
+                     !effort_added) {
+            joint_handles.emplace_back(joint_info.name,
+                                       hardware_interface::HW_IF_EFFORT,
+                                       &joint.transmission_effort);
             effort_added = true;
           }
         };
 
         add_joint_handle(hardware_interface::HW_IF_POSITION);
 
-        if (joint.has_velocity_state)
-        {
+        if (joint.has_velocity_state) {
           add_joint_handle(hardware_interface::HW_IF_VELOCITY);
         }
 
-        if (joint.has_effort_state)
-        {
+        if (joint.has_effort_state) {
           add_joint_handle(hardware_interface::HW_IF_EFFORT);
         }
 
-        for (const auto & cmd_iface : joint_info.command_interfaces)
-        {
+        for (const auto &cmd_iface : joint_info.command_interfaces) {
           add_joint_handle(cmd_iface);
         }
 
-        for (const auto & state_iface : joint_info.state_interfaces)
-        {
+        for (const auto &state_iface : joint_info.state_interfaces) {
           add_joint_handle(state_iface);
         }
       }
@@ -264,15 +242,15 @@ public:
       std::vector<transmission_interface::ActuatorHandle> actuator_handles;
       actuator_handles.reserve(transmission_info.actuators.size() * 3);
 
-      for (const auto & actuator_info : transmission_info.actuators)
-      {
-        auto & actuator = get_actuator(actuator_info.name);
+      for (const auto &actuator_info : transmission_info.actuators) {
+        auto &actuator = get_actuator(actuator_info.name);
 
-        if (!actuator.configured)
-        {
+        if (!actuator.configured) {
           RCLCPP_ERROR(node_->get_logger(),
-            "Transmission '%s' references actuator '%s' with no configured device",
-            transmission_info.name.c_str(), actuator_info.name.c_str());
+                       "Transmission '%s' references actuator '%s' with no "
+                       "configured device",
+                       transmission_info.name.c_str(),
+                       actuator_info.name.c_str());
           return CallbackReturn::ERROR;
         }
 
@@ -280,158 +258,139 @@ public:
         bool velocity_added = false;
         bool effort_added = false;
 
-        auto add_actuator_handle = [&](const std::string & interface) {
-          if (interface == hardware_interface::HW_IF_POSITION && !position_added)
-          {
-            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_POSITION,
-              &actuator.transmission_passthrough);
+        auto add_actuator_handle = [&](const std::string &interface) {
+          if (interface == hardware_interface::HW_IF_POSITION &&
+              !position_added) {
+            actuator_handles.emplace_back(actuator_info.name,
+                                          hardware_interface::HW_IF_POSITION,
+                                          &actuator.transmission_passthrough);
             position_added = true;
-          }
-          else if (interface == hardware_interface::HW_IF_VELOCITY && !velocity_added)
-          {
-            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_VELOCITY,
-              &actuator.transmission_velocity);
+          } else if (interface == hardware_interface::HW_IF_VELOCITY &&
+                     !velocity_added) {
+            actuator_handles.emplace_back(actuator_info.name,
+                                          hardware_interface::HW_IF_VELOCITY,
+                                          &actuator.transmission_velocity);
             velocity_added = true;
-          }
-          else if (interface == hardware_interface::HW_IF_EFFORT && !effort_added)
-          {
-            actuator_handles.emplace_back(actuator_info.name, hardware_interface::HW_IF_EFFORT,
-              &actuator.transmission_effort);
+          } else if (interface == hardware_interface::HW_IF_EFFORT &&
+                     !effort_added) {
+            actuator_handles.emplace_back(actuator_info.name,
+                                          hardware_interface::HW_IF_EFFORT,
+                                          &actuator.transmission_effort);
             effort_added = true;
           }
         };
 
         add_actuator_handle(hardware_interface::HW_IF_POSITION);
 
-        if (actuator.velocity_ptr)
-        {
+        if (actuator.velocity_ptr) {
           add_actuator_handle(hardware_interface::HW_IF_VELOCITY);
         }
 
-        if (actuator.effort_ptr)
-        {
+        if (actuator.effort_ptr) {
           add_actuator_handle(hardware_interface::HW_IF_EFFORT);
         }
 
-        for (const auto & cmd_iface : actuator_info.command_interfaces)
-        {
+        for (const auto &cmd_iface : actuator_info.command_interfaces) {
           add_actuator_handle(cmd_iface);
         }
 
-        for (const auto & state_iface : actuator_info.state_interfaces)
-        {
+        for (const auto &state_iface : actuator_info.state_interfaces) {
           add_actuator_handle(state_iface);
         }
       }
 
-      try
-      {
+      try {
         transmission->configure(joint_handles, actuator_handles);
-      }
-      catch (const transmission_interface::TransmissionInterfaceException & ex)
-      {
-        RCLCPP_ERROR(node_->get_logger(), "Error while configuring transmission '%s': %s",
-          transmission_info.name.c_str(), ex.what());
+      } catch (
+          const transmission_interface::TransmissionInterfaceException &ex) {
+        RCLCPP_ERROR(node_->get_logger(),
+                     "Error while configuring transmission '%s': %s",
+                     transmission_info.name.c_str(), ex.what());
         return CallbackReturn::ERROR;
       }
 
       transmissions_.push_back(std::move(transmission));
     }
 
-    if (transmissions_.empty())
-    {
-      RCLCPP_ERROR(node_->get_logger(), "No transmissions defined for CAN hardware interface");
+    if (transmissions_.empty()) {
+      RCLCPP_ERROR(node_->get_logger(),
+                   "No transmissions defined for CAN hardware interface");
       return CallbackReturn::ERROR;
     }
 
-    RCLCPP_INFO(node_->get_logger(), "CanHW initialised: %zu joints, %zu actuators, %zu transmissions",
-      joints_.size(), actuators_.size(), transmissions_.size());
+    RCLCPP_INFO(
+        node_->get_logger(),
+        "CanHW initialised: %zu joints, %zu actuators, %zu transmissions",
+        joints_.size(), actuators_.size(), transmissions_.size());
 
     return CallbackReturn::SUCCESS;
   }
 
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() override
-  {
+  std::vector<hardware_interface::StateInterface>
+  export_state_interfaces() override {
     std::vector<hardware_interface::StateInterface> interfaces;
     interfaces.reserve(info_.joints.size() * 3);
 
-    for (const auto & joint : info_.joints)
-    {
+    for (const auto &joint : info_.joints) {
       auto it = joint_index_.find(joint.name);
-      if (it == joint_index_.end())
-      {
+      if (it == joint_index_.end()) {
         continue;
       }
 
-      auto & joint_data = joints_[it->second];
+      auto &joint_data = joints_[it->second];
 
       interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
-        &joint_data.state);
+                              &joint_data.state);
 
-      if (joint_data.has_velocity_state)
-      {
+      if (joint_data.has_velocity_state) {
         interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY,
-          &joint_data.velocity);
+                                &joint_data.velocity);
       }
 
-      if (joint_data.has_effort_state)
-      {
+      if (joint_data.has_effort_state) {
         interfaces.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT,
-          &joint_data.effort);
+                                &joint_data.effort);
       }
     }
 
     return interfaces;
   }
 
-  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
-  {
+  std::vector<hardware_interface::CommandInterface>
+  export_command_interfaces() override {
     std::vector<hardware_interface::CommandInterface> interfaces;
     interfaces.reserve(info_.joints.size());
 
-    for (const auto & joint : info_.joints)
-    {
+    for (const auto &joint : info_.joints) {
       auto it = joint_index_.find(joint.name);
-      if (it == joint_index_.end())
-      {
+      if (it == joint_index_.end()) {
         continue;
       }
 
       interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION,
-        &joints_[it->second].command);
+                              &joints_[it->second].command);
     }
 
     return interfaces;
   }
 
-  return_type read(const rclcpp::Time &, const rclcpp::Duration &) override
-  {
-    for (auto & actuator : actuators_)
-    {
-      if (actuator.state_ptr)
-      {
+  return_type read(const rclcpp::Time &, const rclcpp::Duration &) override {
+    for (auto &actuator : actuators_) {
+      if (actuator.state_ptr) {
         actuator.state = *actuator.state_ptr;
-      }
-      else
-      {
+      } else {
         actuator.state = 0.0;
       }
 
-      if (actuator.velocity_ptr)
-      {
+      if (actuator.velocity_ptr) {
         actuator.velocity = *actuator.velocity_ptr;
-      }
-      else
-      {
+      } else {
         actuator.velocity = 0.0;
       }
 
-      if (actuator.effort_ptr)
-      {
+      if (actuator.effort_ptr) {
         actuator.effort = *actuator.effort_ptr;
-      }
-      else
-      {
+      } else {
         actuator.effort = 0.0;
       }
 
@@ -440,13 +399,11 @@ public:
       actuator.transmission_effort = actuator.effort;
     }
 
-    for (auto & transmission : transmissions_)
-    {
+    for (auto &transmission : transmissions_) {
       transmission->actuator_to_joint();
     }
 
-    for (auto & joint : joints_)
-    {
+    for (auto &joint : joints_) {
       joint.state = joint.transmission_passthrough;
       joint.velocity = joint.transmission_velocity;
       joint.effort = joint.transmission_effort;
@@ -455,32 +412,27 @@ public:
     return return_type::OK;
   }
 
-  return_type write(const rclcpp::Time & now, const rclcpp::Duration &) override
-  {
-    for (auto & joint : joints_)
-    {
+  return_type write(const rclcpp::Time &now,
+                    const rclcpp::Duration &) override {
+    for (auto &joint : joints_) {
       joint.transmission_passthrough = joint.command;
       joint.transmission_velocity = 0.0;
       joint.transmission_effort = 0.0;
     }
 
-    for (auto & transmission : transmissions_)
-    {
+    for (auto &transmission : transmissions_) {
       transmission->joint_to_actuator();
     }
 
-    for (auto & actuator : actuators_)
-    {
+    for (auto &actuator : actuators_) {
       actuator.command = actuator.transmission_passthrough;
 
-      if (actuator.command_ptr)
-      {
+      if (actuator.command_ptr) {
         *actuator.command_ptr = actuator.command;
       }
     }
 
-    for (auto & dev : devs_)
-    {
+    for (auto &dev : devs_) {
       dev->process(now);
     }
 
@@ -488,12 +440,8 @@ public:
   }
 
 private:
-  struct JointData
-  {
-    explicit JointData(std::string name_in)
-    : name(std::move(name_in))
-    {
-    }
+  struct JointData {
+    explicit JointData(std::string name_in) : name(std::move(name_in)) {}
 
     std::string name;
     double command{0.0};
@@ -508,12 +456,8 @@ private:
     bool has_effort_state{false};
   };
 
-  struct ActuatorData
-  {
-    explicit ActuatorData(std::string name_in)
-    : name(std::move(name_in))
-    {
-    }
+  struct ActuatorData {
+    explicit ActuatorData(std::string name_in) : name(std::move(name_in)) {}
 
     std::string name;
     double command{0.0};
@@ -523,18 +467,16 @@ private:
     double transmission_passthrough{0.0};
     double transmission_velocity{0.0};
     double transmission_effort{0.0};
-    double * state_ptr{nullptr};
-    double * velocity_ptr{nullptr};
-    double * effort_ptr{nullptr};
-    double * command_ptr{nullptr};
+    double *state_ptr{nullptr};
+    double *velocity_ptr{nullptr};
+    double *effort_ptr{nullptr};
+    double *command_ptr{nullptr};
     bool configured{false};
   };
 
-  JointData & get_joint(const std::string & name)
-  {
+  JointData &get_joint(const std::string &name) {
     auto it = joint_index_.find(name);
-    if (it == joint_index_.end())
-    {
+    if (it == joint_index_.end()) {
       joints_.emplace_back(name);
       joint_index_[name] = joints_.size() - 1;
       return joints_.back();
@@ -543,11 +485,9 @@ private:
     return joints_[it->second];
   }
 
-  ActuatorData & get_actuator(const std::string & name)
-  {
+  ActuatorData &get_actuator(const std::string &name) {
     auto it = actuator_index_.find(name);
-    if (it == actuator_index_.end())
-    {
+    if (it == actuator_index_.end()) {
       actuators_.emplace_back(name);
       actuator_index_[name] = actuators_.size() - 1;
       return actuators_.back();
@@ -563,7 +503,8 @@ private:
   std::unordered_map<std::string, size_t> actuator_index_;
   std::vector<JointData> joints_;
   std::vector<ActuatorData> actuators_;
-  std::vector<std::shared_ptr<transmission_interface::Transmission>> transmissions_;
+  std::vector<std::shared_ptr<transmission_interface::Transmission>>
+      transmissions_;
 
   std::vector<double *> pos_ptrs_;
   std::vector<double *> vel_ptrs_;
@@ -573,8 +514,8 @@ private:
   rclcpp::Node::SharedPtr node_;
 };
 
-}  // namespace mr2_can_hardware_interface
+} // namespace mr2_can_hardware_interface
 
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(mr2_can_hardware_interface::CanHW, hardware_interface::SystemInterface)
-
+PLUGINLIB_EXPORT_CLASS(mr2_can_hardware_interface::CanHW,
+                       hardware_interface::SystemInterface)

--- a/src/mr2_devices_ak_servo/CMakeLists.txt
+++ b/src/mr2_devices_ak_servo/CMakeLists.txt
@@ -14,11 +14,17 @@ add_library(ak_servo_device SHARED src/ak_servo_device.cpp)
 ament_target_dependencies(ak_servo_device
   mr2_can_bus_core hardware_interface pluginlib rclcpp)
 
+add_executable(mock_ak_servo_node src/mock_ak_servo_node.cpp)
+ament_target_dependencies(mock_ak_servo_node mr2_can_bus_core rclcpp)
+
 # export plugin
 pluginlib_export_plugin_description_file(mr2_can_bus_core plugin.xml)
 
 install(TARGETS ak_servo_device
         LIBRARY DESTINATION lib)
+
+install(TARGETS mock_ak_servo_node
+        RUNTIME DESTINATION lib/${PROJECT_NAME})
 
 install(FILES plugin.xml
         DESTINATION share/${PROJECT_NAME})

--- a/src/mr2_devices_ak_servo/src/ak_servo_device.cpp
+++ b/src/mr2_devices_ak_servo/src/ak_servo_device.cpp
@@ -1,82 +1,79 @@
-#include <cmath>
-#include "mr2_can_bus_core/can_device.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "mr2_can_bus_core/can_device.hpp"
 #include "pluginlib/class_list_macros.hpp"
+#include <cmath>
 
-namespace mr2_devices_ak_servo
-{
+namespace mr2_devices_ak_servo {
 
-class AkServoDevice : public CanDevice
-{
+class AkServoDevice : public CanDevice {
 public:
-  void configure(const hardware_interface::ComponentInfo & ji,
-                 rclcpp::Node * node) override
-  {
-    node_   = node;
-    id_     = std::stoi(ji.parameters.at("motor_id"));
-    iface_  = ji.parameters.at("can_iface");        // e.g. "can0"
+  void configure(const hardware_interface::ComponentInfo &ji,
+                 rclcpp::Node *node) override {
+    node_ = node;
+    id_ = std::stoi(ji.parameters.at("motor_id"));
+    iface_ = ji.parameters.at("can_iface"); // e.g. "can0"
 
     // obtain bus & store shared_ptr
     bus_ = CanBusRegistry::get(iface_, 1'000'000);
-    if (!bus_) throw std::runtime_error("Cannot open CAN bus");
+    if (!bus_)
+      throw std::runtime_error("Cannot open CAN bus");
 
     // register listener for periodic 0x29<ID> status frames
     add_filter(bus_, 0x00002900 | id_, 0x1FFFFFFF,
-               [this](const can_frame & f){ on_status(f); });
+               [this](const can_frame &f) { on_status(f); });
 
     // allocate state/command scalars
-    pos_.push_back(0.0); vel_.push_back(0.0);
-    eff_.push_back(0.0); cmd_.push_back(0.0);
+    pos_.push_back(0.0);
+    vel_.push_back(0.0);
+    eff_.push_back(0.0);
+    cmd_.push_back(0.0);
   }
 
-  void process(const rclcpp::Time &) override
-  {
-    struct can_frame fr{};
-    fr.can_id  = (0x00000400 | id_) | CAN_EFF_FLAG;   // Control-ID 4
+  void process(const rclcpp::Time &) override {
+    struct can_frame fr {};
+    fr.can_id = (0x00000400 | id_) | CAN_EFF_FLAG; // Control-ID 4
     fr.can_dlc = 8;
-    int32_t p  = std::lround(cmd_[0] * 180.0 / M_PI * 1e4);
+    int32_t p = std::lround(cmd_[0] * 180.0 / M_PI * 1e4);
     fr.data[0] = (p >> 24) & 0xFF;
     fr.data[1] = (p >> 16) & 0xFF;
-    fr.data[2] = (p >>  8) & 0xFF;
-    fr.data[3] = (p      ) & 0xFF;
-    fr.data[4] = fr.data[5] = fr.data[6] = fr.data[7] = 0;   // vel/acc = 0
+    fr.data[2] = (p >> 8) & 0xFF;
+    fr.data[3] = (p)&0xFF;
+    fr.data[4] = fr.data[5] = fr.data[6] = fr.data[7] = 0; // vel/acc = 0
     send(fr, bus_);
   }
 
-  void export_state(std::vector<double*> & pos,
-                    std::vector<double*> & vel,
-                    std::vector<double*> & eff) override
-  {
+  void export_state(std::vector<double *> &pos, std::vector<double *> &vel,
+                    std::vector<double *> &eff) override {
     pos.push_back(&pos_[0]);
     vel.push_back(&vel_[0]);
     eff.push_back(&eff_[0]);
   }
 
-  void export_command(std::vector<double*> & cmd) override
-  { cmd.push_back(&cmd_[0]); }
+  void export_command(std::vector<double *> &cmd) override {
+    cmd.push_back(&cmd_[0]);
+  }
 
 private:
   /* -------- CAN status-frame callback -------- */
-  void on_status(const can_frame & f)
-  {
+  void on_status(const can_frame &f) {
     int16_t p10 = (f.data[0] << 8) | f.data[1];
     int16_t v10 = (f.data[2] << 8) | f.data[3];
     int16_t c01 = (f.data[4] << 8) | f.data[5];
 
     pos_[0] = (p10 / 10.0) * (M_PI / 180.0);
-    vel_[0] = (v10 * 10.0) * (M_PI / 30.0);   // rpm→rad/s
-    eff_[0] = c01 / 100.0;                            // amps
+    vel_[0] = (v10 * 10.0) * (M_PI / 30.0); // rpm→rad/s
+    eff_[0] = c01 / 100.0;                  // amps
   }
 
   /* members */
-  rclcpp::Node * node_;
+  rclcpp::Node *node_;
   std::shared_ptr<CanBusManager> bus_;
   std::string iface_;
-  int    id_{0};
+  int id_{0};
 
   std::vector<double> pos_, vel_, eff_, cmd_;
 };
 
-}  // namespace mr2_devices_ak_servo
+} // namespace mr2_devices_ak_servo
 
 PLUGINLIB_EXPORT_CLASS(mr2_devices_ak_servo::AkServoDevice, CanDevice)

--- a/src/mr2_devices_ak_servo/src/mock_ak_servo_node.cpp
+++ b/src/mr2_devices_ak_servo/src/mock_ak_servo_node.cpp
@@ -1,0 +1,165 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <linux/can.h>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "mr2_can_bus_core/can_bus_manager.hpp"
+#include "mr2_can_bus_core/can_bus_registry.hpp"
+
+using namespace std::chrono_literals;
+
+class MockAkServoNode : public rclcpp::Node {
+public:
+  MockAkServoNode() : rclcpp::Node("mock_ak_servo") {
+    can_iface_ = declare_parameter<std::string>("can_iface", "vcan0");
+    servo_id_ = declare_parameter<int>("motor_id", 4);
+    update_rate_hz_ = declare_parameter<double>("update_rate_hz", 200.0);
+    max_velocity_rad_s_ = declare_parameter<double>("max_velocity", 4.0);
+    effort_gain_ = declare_parameter<double>("effort_gain", 4.0);
+    max_effort_amp_ = declare_parameter<double>("max_effort_amp", 6.0);
+
+    if (update_rate_hz_ <= 0.0) {
+      throw std::runtime_error("update_rate_hz must be positive");
+    }
+
+    bus_ = CanBusRegistry::get(can_iface_);
+    if (!bus_) {
+      throw std::runtime_error("Failed to acquire CAN bus on interface '" +
+                               can_iface_ + "'");
+    }
+
+    const uint32_t command_filter_id =
+        0x00000400u | static_cast<uint32_t>(servo_id_);
+    bus_->register_listener(
+        command_filter_id, 0x1FFFFFFFu,
+        [this](const struct can_frame &frame) { this->handle_command(frame); });
+
+    const auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(1.0 / update_rate_hz_));
+    timer_ =
+        create_wall_timer(period, std::bind(&MockAkServoNode::update, this));
+
+    last_time_ = std::chrono::steady_clock::now();
+    RCLCPP_INFO(get_logger(), "Mock AK servo started on %s id %d",
+                can_iface_.c_str(), servo_id_);
+  }
+
+private:
+  void handle_command(const struct can_frame &frame) {
+    if ((frame.can_id & CAN_EFF_FLAG) == 0) {
+      return;
+    }
+
+    if (frame.can_dlc < 4) {
+      return;
+    }
+
+    const int32_t raw = (static_cast<int32_t>(frame.data[0]) << 24) |
+                        (static_cast<int32_t>(frame.data[1]) << 16) |
+                        (static_cast<int32_t>(frame.data[2]) << 8) |
+                        (static_cast<int32_t>(frame.data[3]));
+
+    const double target_deg = static_cast<double>(raw) / 1e4;
+    const double target_rad = target_deg * M_PI / 180.0;
+
+    std::lock_guard<std::mutex> lock(state_mtx_);
+    target_position_rad_ = target_rad;
+  }
+
+  void update() {
+    const auto now = std::chrono::steady_clock::now();
+    double dt = std::chrono::duration<double>(now - last_time_).count();
+    if (dt <= 0.0) {
+      dt = 1.0 / update_rate_hz_;
+    }
+    last_time_ = now;
+
+    double target;
+    double position;
+    {
+      std::lock_guard<std::mutex> lock(state_mtx_);
+
+      target = target_position_rad_;
+      position = position_rad_;
+
+      const double error = target - position;
+      const double max_step = max_velocity_rad_s_ * dt;
+      const double step = std::clamp(error, -max_step, max_step);
+      position_rad_ += step;
+
+      velocity_rad_s_ = step / dt;
+      effort_amp_ =
+          std::clamp(error * effort_gain_, -max_effort_amp_, max_effort_amp_);
+
+      position = position_rad_;
+    }
+
+    publish_status(position, velocity_rad_s_, effort_amp_);
+  }
+
+  void publish_status(double position, double velocity, double effort) {
+    struct can_frame status {};
+    status.can_id =
+        (0x00002900u | static_cast<uint32_t>(servo_id_)) | CAN_EFF_FLAG;
+    status.can_dlc = 8;
+
+    const int16_t pos_10deg =
+        static_cast<int16_t>(std::lround(position * 180.0 / M_PI * 10.0));
+    const double rpm = velocity * 30.0 / M_PI;
+    const int16_t vel_10rpm = static_cast<int16_t>(std::lround(rpm * 10.0));
+    const int16_t cur_01amp = static_cast<int16_t>(std::lround(effort * 100.0));
+
+    status.data[0] = static_cast<uint8_t>((pos_10deg >> 8) & 0xFF);
+    status.data[1] = static_cast<uint8_t>(pos_10deg & 0xFF);
+    status.data[2] = static_cast<uint8_t>((vel_10rpm >> 8) & 0xFF);
+    status.data[3] = static_cast<uint8_t>(vel_10rpm & 0xFF);
+    status.data[4] = static_cast<uint8_t>((cur_01amp >> 8) & 0xFF);
+    status.data[5] = static_cast<uint8_t>(cur_01amp & 0xFF);
+    status.data[6] = 0;
+    status.data[7] = 0;
+
+    bus_->enqueue_tx(status);
+  }
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::shared_ptr<CanBusManager> bus_;
+
+  std::string can_iface_;
+  int servo_id_{4};
+  double update_rate_hz_{200.0};
+  double max_velocity_rad_s_{4.0};
+  double effort_gain_{4.0};
+  double max_effort_amp_{6.0};
+
+  std::mutex state_mtx_;
+  double target_position_rad_{0.0};
+  double position_rad_{0.0};
+  double velocity_rad_s_{0.0};
+  double effort_amp_{0.0};
+
+  std::chrono::steady_clock::time_point last_time_{};
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  try {
+    rclcpp::spin(std::make_shared<MockAkServoNode>());
+  } catch (const std::exception &ex) {
+    RCLCPP_FATAL(rclcpp::get_logger("mock_ak_servo"), "Unhandled exception: %s",
+                 ex.what());
+    rclcpp::shutdown();
+    return EXIT_FAILURE;
+  }
+
+  rclcpp::shutdown();
+  return EXIT_SUCCESS;
+}

--- a/src/mr2_rover_control/CMakeLists.txt
+++ b/src/mr2_rover_control/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(mr2_rover_control)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/src/mr2_rover_control/include/mr2_rover_control/twist_to_commands_controller.hpp
+++ b/src/mr2_rover_control/include/mr2_rover_control/twist_to_commands_controller.hpp
@@ -1,34 +1,35 @@
 #pragma once
 
-#include <vector>
-#include <string>
 #include <array>
+#include <string>
+#include <vector>
 
 #include "controller_interface/controller_interface.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
-#include "geometry_msgs/msg/twist.hpp"
 
-namespace mr2_rover_control
-{
+namespace mr2_rover_control {
 
-class TwistToCommandsController : public controller_interface::ControllerInterface
-{
+class TwistToCommandsController
+    : public controller_interface::ControllerInterface {
 public:
   controller_interface::CallbackReturn on_init() override;
 
-  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
-  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration
+  command_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration
+  state_interface_configuration() const override;
 
-  controller_interface::CallbackReturn on_configure(
-    const rclcpp_lifecycle::State & previous_state) override;
-  controller_interface::CallbackReturn on_activate(
-    const rclcpp_lifecycle::State & previous_state) override;
-  controller_interface::CallbackReturn on_deactivate(
-    const rclcpp_lifecycle::State & previous_state) override;
+  controller_interface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &previous_state) override;
+  controller_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &previous_state) override;
+  controller_interface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
 
-  controller_interface::return_type update(
-    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+  controller_interface::return_type
+  update(const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
 private:
   void twistCb(const geometry_msgs::msg::Twist::SharedPtr msg);
@@ -48,5 +49,4 @@ private:
   geometry_msgs::msg::Twist last_twist_;
 };
 
-}  // namespace mr2_rover_control
-
+} // namespace mr2_rover_control

--- a/src/mr2_rover_control/src/twist_to_commands_controller.cpp
+++ b/src/mr2_rover_control/src/twist_to_commands_controller.cpp
@@ -5,11 +5,9 @@
 
 #include "pluginlib/class_list_macros.hpp"
 
-namespace mr2_rover_control
-{
+namespace mr2_rover_control {
 
-controller_interface::CallbackReturn TwistToCommandsController::on_init()
-{
+controller_interface::CallbackReturn TwistToCommandsController::on_init() {
   auto_declare<std::vector<std::string>>("wheel_joints", {});
   auto_declare<std::vector<std::string>>("steering_joints", {});
   auto_declare<double>("wheel_base", 0.94);
@@ -21,34 +19,34 @@ controller_interface::CallbackReturn TwistToCommandsController::on_init()
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::InterfaceConfiguration TwistToCommandsController::command_interface_configuration() const
-{
+controller_interface::InterfaceConfiguration
+TwistToCommandsController::command_interface_configuration() const {
   controller_interface::InterfaceConfiguration conf;
   conf.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-  for (const auto & joint : wheel_joints_) {
+  for (const auto &joint : wheel_joints_) {
     conf.names.push_back(joint + "/velocity");
   }
-  for (const auto & joint : steering_joints_) {
+  for (const auto &joint : steering_joints_) {
     conf.names.push_back(joint + "/position");
   }
   return conf;
 }
 
-controller_interface::InterfaceConfiguration TwistToCommandsController::state_interface_configuration() const
-{
+controller_interface::InterfaceConfiguration
+TwistToCommandsController::state_interface_configuration() const {
   controller_interface::InterfaceConfiguration conf;
   conf.type = controller_interface::interface_configuration_type::NONE;
   return conf;
 }
 
-controller_interface::CallbackReturn TwistToCommandsController::on_configure(
-  const rclcpp_lifecycle::State &)
-{
+controller_interface::CallbackReturn
+TwistToCommandsController::on_configure(const rclcpp_lifecycle::State &) {
   wheel_joints_ = get_node()->get_parameter("wheel_joints").as_string_array();
-  steering_joints_ = get_node()->get_parameter("steering_joints").as_string_array();
+  steering_joints_ =
+      get_node()->get_parameter("steering_joints").as_string_array();
   if (wheel_joints_.size() != 4 || steering_joints_.size() != 4) {
     RCLCPP_ERROR(get_node()->get_logger(),
-      "Expected 4 wheel joints and 4 steering joints");
+                 "Expected 4 wheel joints and 4 steering joints");
     return controller_interface::CallbackReturn::ERROR;
   }
   wheel_base_ = get_node()->get_parameter("wheel_base").as_double();
@@ -59,8 +57,9 @@ controller_interface::CallbackReturn TwistToCommandsController::on_configure(
   const auto cmd_topic = get_node()->get_parameter("cmd_vel_topic").as_string();
 
   sub_twist_ = get_node()->create_subscription<geometry_msgs::msg::Twist>(
-    cmd_topic, rclcpp::SystemDefaultsQoS(),
-    std::bind(&TwistToCommandsController::twistCb, this, std::placeholders::_1));
+      cmd_topic, rclcpp::SystemDefaultsQoS(),
+      std::bind(&TwistToCommandsController::twistCb, this,
+                std::placeholders::_1));
 
   last_twist_.linear.x = 0.0;
   last_twist_.angular.z = 0.0;
@@ -68,37 +67,34 @@ controller_interface::CallbackReturn TwistToCommandsController::on_configure(
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::CallbackReturn TwistToCommandsController::on_activate(
-  const rclcpp_lifecycle::State &)
-{
+controller_interface::CallbackReturn
+TwistToCommandsController::on_activate(const rclcpp_lifecycle::State &) {
   publishZeros();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::CallbackReturn TwistToCommandsController::on_deactivate(
-  const rclcpp_lifecycle::State &)
-{
+controller_interface::CallbackReturn
+TwistToCommandsController::on_deactivate(const rclcpp_lifecycle::State &) {
   publishZeros();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-void TwistToCommandsController::twistCb(const geometry_msgs::msg::Twist::SharedPtr msg)
-{
+void TwistToCommandsController::twistCb(
+    const geometry_msgs::msg::Twist::SharedPtr msg) {
   last_twist_ = *msg;
   last_twist_time_ = get_node()->now();
 }
 
-void TwistToCommandsController::publishZeros()
-{
+void TwistToCommandsController::publishZeros() {
   for (size_t i = 0; i < 4; ++i) {
     command_interfaces_[i].set_value(0.0);
     command_interfaces_[i + 4].set_value(0.0);
   }
 }
 
-controller_interface::return_type TwistToCommandsController::update(
-  const rclcpp::Time &, const rclcpp::Duration &)
-{
+controller_interface::return_type
+TwistToCommandsController::update(const rclcpp::Time &,
+                                  const rclcpp::Duration &) {
   if ((get_node()->now() - last_twist_time_).seconds() > timeout_) {
     publishZeros();
     return controller_interface::return_type::OK;
@@ -111,19 +107,22 @@ controller_interface::return_type TwistToCommandsController::update(
   const double hx = wheel_base_ * 0.5;
   const double hy = track_width_ * 0.5;
 
-  struct Wheel { double x; double y; };
-  const std::array<Wheel,4> wheels = {{
-    { +hx, -hy },  // FL
-    { +hx, +hy },  // FR
-    { -hx, -hy },  // RL
-    { -hx, +hy }   // RR
+  struct Wheel {
+    double x;
+    double y;
+  };
+  const std::array<Wheel, 4> wheels = {{
+      {+hx, -hy}, // FL
+      {+hx, +hy}, // FR
+      {-hx, -hy}, // RL
+      {-hx, +hy}  // RR
   }};
 
-  std::array<double,4> steer{};
-  std::array<double,4> speed{};
+  std::array<double, 4> steer{};
+  std::array<double, 4> speed{};
 
   for (size_t i = 0; i < wheels.size(); ++i) {
-    const auto & w = wheels[i];
+    const auto &w = wheels[i];
     const double vx_i = vx - wz * w.y;
     const double vy_i = vy + wz * w.x;
     double ang = std::atan2(vy_i, vx_i);
@@ -145,7 +144,7 @@ controller_interface::return_type TwistToCommandsController::update(
   return controller_interface::return_type::OK;
 }
 
-}  // namespace mr2_rover_control
+} // namespace mr2_rover_control
 
-PLUGINLIB_EXPORT_CLASS(mr2_rover_control::TwistToCommandsController, controller_interface::ControllerInterface)
-
+PLUGINLIB_EXPORT_CLASS(mr2_rover_control::TwistToCommandsController,
+                       controller_interface::ControllerInterface)

--- a/src/mr2_rover_description/launch/single_joint.launch.py
+++ b/src/mr2_rover_description/launch/single_joint.launch.py
@@ -1,5 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, TimerAction
+from launch.conditions import IfCondition
 from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -25,6 +26,13 @@ def generate_launch_description():
         description="CAN interface used by the AK servo hardware",
     )
 
+    use_mock_servo = LaunchConfiguration("use_mock_servo")
+    use_mock_servo_arg = DeclareLaunchArgument(
+        "use_mock_servo",
+        default_value="true",
+        description="Start mock AK servo that emulates CAN feedback",
+    )
+
     robot_description = {
         "robot_description": Command([
             "xacro ",
@@ -34,10 +42,11 @@ def generate_launch_description():
         ])
     }
 
-    rsp = Node(
+    robot_state_publisher_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         parameters=[robot_description],
+        output="screen",
     )
 
     ros2_control_node = Node(
@@ -45,6 +54,17 @@ def generate_launch_description():
         executable="ros2_control_node",
         parameters=[controller_yaml],
         remappings=[("/controller_manager/robot_description", "/robot_description")],
+        output="screen",
+    )
+
+    mock_servo_node = Node(
+        package="mr2_devices_ak_servo",
+        executable="mock_ak_servo_node",
+        parameters=[{
+            "can_iface": can_iface,
+            "motor_id": 4,
+        }],
+        condition=IfCondition(use_mock_servo),
         output="screen",
     )
 
@@ -63,10 +83,11 @@ def generate_launch_description():
     return LaunchDescription(
         [
             can_iface_arg,
-            rsp,
+            use_mock_servo_arg,
+            robot_state_publisher_node,
+            mock_servo_node,
             ros2_control_node,
             TimerAction(period=2.0, actions=[jsb_spawner]),
             TimerAction(period=3.0, actions=[joint_spawner]),
         ]
     )
-

--- a/src/mr2_rover_description/ros2_control/manipulator_ak_can.ros2_control.xacro
+++ b/src/mr2_rover_description/ros2_control/manipulator_ak_can.ros2_control.xacro
@@ -11,6 +11,8 @@
       <joint name="arm_j1">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor1</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">1</param>
@@ -20,6 +22,8 @@
       <joint name="arm_j2">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor2</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">2</param>
@@ -29,6 +33,8 @@
       <joint name="arm_j3">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor3</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">3</param>
@@ -38,6 +44,8 @@
       <joint name="arm_j4">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor4</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">4</param>
@@ -47,6 +55,8 @@
       <joint name="arm_j5">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor5</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">5</param>
@@ -56,6 +66,8 @@
       <joint name="arm_j6">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
         <param name="actuator">motor6</param>
         <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
         <param name="motor_id">6</param>
@@ -67,6 +79,8 @@
         <actuator name="motor1" role="motor1">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
         </actuator>
         <joint name="arm_j1" role="arm_j1">
           <mechanical_reduction>1.0</mechanical_reduction>
@@ -78,11 +92,15 @@
         <actuator name="motor2" role="motor2">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
           <mechanical_reduction>1.0</mechanical_reduction>
         </actuator>
         <actuator name="motor3" role="motor3">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
           <mechanical_reduction>1.0</mechanical_reduction>
         </actuator>
         <joint name="arm_j2" role="arm_j2">
@@ -100,6 +118,8 @@
         <actuator name="motor4" role="motor4">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
         </actuator>
         <joint name="arm_j4" role="arm_j4">
           <mechanical_reduction>1.0</mechanical_reduction>
@@ -111,6 +131,8 @@
         <actuator name="motor5" role="motor5">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
         </actuator>
         <joint name="arm_j5" role="arm_j5">
           <mechanical_reduction>1.0</mechanical_reduction>
@@ -122,6 +144,8 @@
         <actuator name="motor6" role="motor6">
           <command_interface name="position"/>
           <state_interface name="position"/>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
         </actuator>
         <joint name="arm_j6" role="arm_j6">
           <mechanical_reduction>1.0</mechanical_reduction>

--- a/src/mr2_rover_description/urdf/single_joint.urdf.xacro
+++ b/src/mr2_rover_description/urdf/single_joint.urdf.xacro
@@ -2,8 +2,29 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="single_joint">
   <xacro:arg name="can_iface" default="can0"/>
 
-  <link name="base_link"/>
-  <link name="link1"/>
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.025" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.05"/>
+      </geometry>
+      <material name="base_blue">
+        <color rgba="0.2 0.2 0.8 1.0"/>
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0.15 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.3 0.05 0.05"/>
+      </geometry>
+      <material name="link_orange">
+        <color rgba="0.9 0.5 0.2 1.0"/>
+      </material>
+    </visual>
+  </link>
 
   <joint name="joint1" type="revolute">
     <parent link="base_link"/>
@@ -43,4 +64,3 @@
     </transmission>
   </ros2_control>
 </robot>
-

--- a/src/mr2_rover_description/urdf/single_joint.urdf.xacro
+++ b/src/mr2_rover_description/urdf/single_joint.urdf.xacro
@@ -21,6 +21,8 @@
     <joint name="joint1">
       <command_interface name="position"/>
       <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
       <param name="actuator">motor4</param>
       <param name="device_plugin">mr2_devices_ak_servo/AkServoDevice</param>
       <param name="motor_id">4</param>
@@ -32,6 +34,8 @@
       <actuator name="motor4" role="motor4">
         <command_interface name="position"/>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
       </actuator>
       <joint name="joint1" role="joint1">
         <mechanical_reduction>1.0</mechanical_reduction>


### PR DESCRIPTION
## Summary
- propagate velocity and effort state data through the CAN hardware interface
- extend AK servo ros2_control descriptions to declare velocity and effort state interfaces

## Testing
- colcon build --packages-up-to mr2_can_hardware_interface
- colcon build --packages-select mr2_devices_ak_servo mr2_rover_description

------
https://chatgpt.com/codex/tasks/task_e_68e4fbf032d083258a4abb2eb6b25421