### PR TITLE
2026 led driver

### DIFF
--- a/rover/firmware/led_firmware/README.md
+++ b/rover/firmware/led_firmware/README.md
@@ -1,0 +1,57 @@
+# LED Firmware (CAN-Controlled NeoPixels)
+
+Firmware for an STM32 NUCLEO-G431KB that listens on CAN and drives a NeoPixel
+strip. Incoming CAN frames select a display mode (solid color or green blink).
+
+## Hardware
+
+- **Board:** NUCLEO-G431KB only (compile-time guard in the sketch).
+- **NeoPixel data pin:** `D3` (change `NEOPIXEL_PIN` if needed).
+- **LED count:** `256` (change `NUM_PIXELS` to match your strip).
+
+## CAN configuration
+
+- **Library:** `ACANFD_STM32`
+- **Bus type:** Classic CAN (no FD data phase), 1 Mbps nominal.
+- **Acceptance filter:** Only standard ID `0x123` is accepted into FIFO0.
+
+## CAN protocol
+
+This firmware **receives only**; it does not transmit CAN frames.
+
+### Control frame
+
+- **CAN ID:** `0x123` (11-bit standard)
+- **DLC:** 1+ (requires at least one byte)
+- **Data[0]:** mode selector
+
+| Data[0] | Mode             | Effect                                              |
+|--------:|------------------|-----------------------------------------------------|
+| 0       | Off              | All pixels off                                      |
+| 1       | Red              | Solid red (RGB = 50, 0, 0)                           |
+| 2       | Blue             | Solid blue (RGB = 0, 0, 50)                          |
+| 3       | Green Blink      | Blink green at 500 ms (RGB = 0, 50, 0)               |
+
+Values above 3 are ignored.
+
+### Blink behavior
+
+- Blink mode toggles every 500 ms.
+- The blink starts in the "off" state and then alternates on/off.
+
+## Runtime behavior
+
+- On boot, the strip is cleared and set to **Green Blink** by default.
+- CAN frames are polled continuously; mode changes apply immediately.
+- Serial output at 115200 baud logs FDCAN init status and a brief hint.
+
+## Configuration points
+
+- `NEOPIXEL_PIN`, `NUM_PIXELS`
+- `CAN_CONTROL_ID` (default `0x123`)
+- `BLINK_PERIOD_MS` (default 500 ms)
+
+## Notes
+
+- If you change the CAN ID, update both the filter and your sender.
+- Brightness is set to 255; adjust in `setup()` if needed.

--- a/rover/firmware/led_firmware/led_firmware.ino
+++ b/rover/firmware/led_firmware/led_firmware.ino
@@ -1,65 +1,111 @@
-#include <Arduino.h>/private/var/folders/zw/53_149hx0wsbn1lp2xfb0yq00000gn/T/.arduinoIDE-unsaved20251020-3294-11xzl5q.jo94/Blink/Blink.ino
+#ifndef ARDUINO_NUCLEO_G431KB
+#error This sketch is intended for NUCLEO-G431KB
+#endif
 
-const int BUTTON_PIN = D1;    // 푸시 버튼
+#include <ACANFD_STM32.h>
+#include <Adafruit_NeoPixel.h>
 
-// 나중에 MOSFET 제어용 핀도 쓰고 싶으면 예:
-// const int MOSFET_PIN = D2;
+// ---------------------- NeoPixel config ----------------------
+static const uint8_t NEOPIXEL_PIN = D3;  // <-- change to your data pin
+static const uint16_t NUM_PIXELS = 256;   // <-- change to your LED count
+Adafruit_NeoPixel strip(NUM_PIXELS, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
 
-bool sleepMode = false;       // false = 깨어 있음, true = "sleep 모드" 상태
+// ---------------------- CAN config ---------------------------
+static const uint32_t CAN_CONTROL_ID = 0x123;  // standard 11-bit ID
 
-// 디바운스용 변수들
-int lastReading = HIGH;
-int stableState = HIGH;
-unsigned long lastDebounceTime = 0;
-const unsigned long debounceDelay = 50; // ms
+enum Mode : uint8_t {
+  MODE_OFF = 0,
+  MODE_RED = 1,
+  MODE_BLUE = 2,
+  MODE_GREEN_BLINK = 3
+};
 
-void applySleepState() {
-  if (sleepMode) {
-    // ----- Sleep 모드 ON -----
-    digitalWrite(LED_BUILTIN, HIGH);   // 예: Sleep 모드일 때 LED ON
-    // digitalWrite(MOSFET_PIN, LOW);  // 예: MOSFET 끄기 등
-    Serial.println("Sleep mode: ON");
-  } else {
-    // ----- Sleep 모드 OFF -----
-    digitalWrite(LED_BUILTIN, LOW);    // 예: Sleep 모드 아닐 때 LED OFF
-    // digitalWrite(MOSFET_PIN, HIGH); // 예: MOSFET 켜기 등
-    Serial.println("Sleep mode: OFF");
+static volatile Mode gMode = MODE_GREEN_BLINK;
+
+// Green blink @ 500 ms (fixed)
+static const uint32_t BLINK_PERIOD_MS = 500;
+static uint32_t gNextBlinkMs = 0;
+static bool gGreenOn = false;
+
+// ---------------------- Helpers ------------------------------
+static void applySolid(uint32_t color) {
+  for (uint16_t i = 0; i < NUM_PIXELS; i++) strip.setPixelColor(i, color);
+  strip.show();
+}
+
+static void setMode(Mode m) {
+  gMode = m;
+  gGreenOn = false;
+  gNextBlinkMs = millis() + BLINK_PERIOD_MS;
+
+  switch (gMode) {
+    case MODE_OFF: applySolid(strip.Color(0, 0, 0)); break;
+    case MODE_RED: applySolid(strip.Color(50, 0, 0)); break;
+    case MODE_BLUE: applySolid(strip.Color(0, 0, 50)); break;
+    case MODE_GREEN_BLINK: applySolid(strip.Color(0, 0, 0)); break;  // start off
+    default: applySolid(strip.Color(0, 0, 0)); break;
   }
 }
 
+static void pollCanAndUpdateMode() {
+  CANFDMessage msg;
+
+  // Filters below route our ID to FIFO0
+  while (fdcan1.receiveFD0(msg)) {
+    // Standard frame only
+    if (msg.ext) continue;
+    if (msg.id != CAN_CONTROL_ID) continue;
+    if (msg.len < 1) continue;
+
+    const uint8_t v = msg.data[0];
+    if (v <= MODE_GREEN_BLINK) {
+      setMode((Mode)v);
+    }
+  }
+}
+
+static void updateBlink() {
+  if (gMode != MODE_GREEN_BLINK) return;
+
+  const uint32_t now = millis();
+  if ((int32_t)(now - gNextBlinkMs) >= 0) {
+    Serial.println("color change");
+    gNextBlinkMs += BLINK_PERIOD_MS;
+    gGreenOn = !gGreenOn;
+    applySolid(gGreenOn ? strip.Color(0, 50, 0) : strip.Color(0, 0, 0));
+  }
+}
+
+// ---------------------- Arduino setup/loop --------------------
 void setup() {
   Serial.begin(115200);
+  while (!Serial) { delay(10); }
 
-  pinMode(BUTTON_PIN, INPUT_PULLUP); // 버튼: 풀업, GND로 눌리는 방식
-  pinMode(LED_BUILTIN, OUTPUT);
-  // pinMode(MOSFET_PIN, OUTPUT);
+  strip.begin();
+  strip.setBrightness(255);
+  strip.show();  // clear
+  setMode(MODE_GREEN_BLINK);
 
-  digitalWrite(LED_BUILTIN, LOW);
-  // digitalWrite(MOSFET_PIN, HIGH); // 기본은 켜져있다고 가정
+  // Classic CAN @ 1 Mbps (use x1 since we don't need a faster data phase)
+  ACANFD_STM32_Settings settings(1000 * 1000, DataBitRateFactor::x1);
 
-  applySleepState();
+  // Accept ONLY our control ID into FIFO0
+  ACANFD_STM32_StandardFilters filters;
+  filters.addSingle(CAN_CONTROL_ID, ACANFD_STM32_FilterAction::FIFO0);
+  settings.mNonMatchingStandardFrameReception = ACANFD_STM32_FilterAction::REJECT;
+
+  const uint32_t err = fdcan1.beginFD(settings, filters);
+  if (err == 0) {
+    Serial.println("FDCAN started OK");
+  } else {
+    Serial.print("FDCAN beginFD error: 0x");
+    Serial.println(err, HEX);
+  }
+
+  Serial.println("Send StdID 0x123, DLC=1, data[0]=0..3");
 }
 
 void loop() {
-  int reading = digitalRead(BUTTON_PIN);
-
-  // 입력 값이 바뀌면 디바운스 타이머 리셋
-  if (reading != lastReading) {
-    lastDebounceTime = millis();
-  }
-
-  // debounceDelay 동안 값이 안정적이면 "진짜"로 인정
-  if ((millis() - lastDebounceTime) > debounceDelay) {
-    if (reading != stableState) {
-      stableState = reading;
-
-      // 버튼이 눌린 순간 (HIGH -> LOW 엣지에서만 토글)
-      if (stableState == LOW) {
-        sleepMode = !sleepMode;    // 토글
-        applySleepState();
-      }
-    }
-  }
-
-  lastReading = reading;
+  pollCanAndUpdateMode();
+  updateBlink();
 }

--- a/rover/ros2_ws/src/mr2_led/CMakeLists.txt
+++ b/rover/ros2_ws/src/mr2_led/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.10)
+project(mr2_led LANGUAGES CXX)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(mr2_can_bus_core REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/SetLedMode.srv")
+
+ament_export_dependencies(rosidl_default_runtime)
+
+add_executable(led_can_node src/led_can_node.cpp)
+ament_target_dependencies(led_can_node
+  rclcpp
+  mr2_can_bus_core)
+
+rosidl_get_typesupport_target(typesupport_target
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+if(typesupport_target)
+  target_link_libraries(led_can_node ${typesupport_target})
+endif()
+add_dependencies(led_can_node ${PROJECT_NAME}__rosidl_generator_cpp)
+
+install(TARGETS led_can_node
+  RUNTIME DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY srv
+  DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/rover/ros2_ws/src/mr2_led/CMakeLists.txt
+++ b/rover/ros2_ws/src/mr2_led/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(mr2_led LANGUAGES CXX)
+project(mr2_led LANGUAGES C CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/rover/ros2_ws/src/mr2_led/README.md
+++ b/rover/ros2_ws/src/mr2_led/README.md
@@ -1,0 +1,47 @@
+# mr2_led
+
+CAN-controlled LED driver for the MR2 NeoPixel firmware. The node exposes a ROS 2
+service that sends a single CAN frame to set the LED mode.
+
+## CAN protocol
+
+- **CAN ID:** 0x123 (standard 11-bit)
+- **DLC:** 1
+- **Data[0]:** mode selector
+
+| Mode name   | Value | LED behavior                         |
+|-------------|-------|--------------------------------------|
+| OFF         | 0     | All pixels off                       |
+| AUTONOMOUS  | 1     | Solid red                            |
+| MANUAL      | 2     | Solid blue (teleoperation)           |
+| SUCCESS     | 3     | Flashing green (arrived at target)   |
+
+Values above 3 are rejected by the service.
+
+## ROS 2 service
+
+Service type: `mr2_led/srv/SetLedMode`
+
+Request:
+- `uint8 mode`
+
+Response:
+- `bool success`
+- `string message`
+
+Example:
+
+```sh
+ros2 service call /set_led_mode mr2_led/srv/SetLedMode "{mode: 1}"
+```
+
+## Parameters
+
+- `can_iface` (string, default: `can0`) SocketCAN interface.
+- `can_id` (int, default: `0x123`) Standard 11-bit CAN ID.
+
+## Launch
+
+```sh
+ros2 launch mr2_led led_can.launch.py
+```

--- a/rover/ros2_ws/src/mr2_led/README.md
+++ b/rover/ros2_ws/src/mr2_led/README.md
@@ -3,6 +3,15 @@
 CAN-controlled LED driver for the MR2 NeoPixel firmware. The node exposes a ROS 2
 service that sends a single CAN frame to set the LED mode.
 
+## Quick start
+
+```bash
+source install/setup.bash            # after colcon build
+ros2 launch mr2_led led_can.launch.py can_iface:=can0 can_id:=0x123
+# In another terminal (sourced):
+ros2 service call /set_led_mode mr2_led/srv/SetLedMode "{mode: 2}"
+```
+
 ## CAN protocol
 
 - **CAN ID:** 0x123 (standard 11-bit)
@@ -40,8 +49,38 @@ ros2 service call /set_led_mode mr2_led/srv/SetLedMode "{mode: 1}"
 - `can_iface` (string, default: `can0`) SocketCAN interface.
 - `can_id` (int, default: `0x123`) Standard 11-bit CAN ID.
 
-## Launch
+## Launch options
 
 ```sh
-ros2 launch mr2_led led_can.launch.py
+ros2 launch mr2_led led_can.launch.py can_iface:=can0 can_id:=0x123
 ```
+
+## Development / build
+
+From the workspace root:
+
+```bash
+colcon build --packages-select mr2_led
+source install/setup.bash
+```
+
+The package depends on `mr2_can_bus_core` for SocketCAN transport and `rosidl_default_generators` for the service type.
+
+## Testing without hardware
+
+Set up a virtual CAN bus and run the node against it:
+
+```bash
+sudo ip link add dev vcan0 type vcan
+sudo ip link set vcan0 up
+source install/setup.bash
+ros2 launch mr2_led led_can.launch.py can_iface:=vcan0
+ros2 service call /set_led_mode mr2_led/srv/SetLedMode "{mode: 3}"
+```
+
+This lets you exercise the service interface even when no real CAN interface is present.
+
+## Troubleshooting
+
+- `Invalid CAN ID` at startup: ensure `can_id` is within 0–0x7FF (11-bit standard frame).
+- `Failed to acquire CAN bus`: confirm the `can_iface` exists and is `UP` (`ip link show can0`).

--- a/rover/ros2_ws/src/mr2_led/launch/led_can.launch.py
+++ b/rover/ros2_ws/src/mr2_led/launch/led_can.launch.py
@@ -1,0 +1,15 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="mr2_led",
+                executable="led_can_node",
+                name="mr2_led",
+                parameters=[{"can_iface": "can0", "can_id": 0x123}],
+            )
+        ]
+    )

--- a/rover/ros2_ws/src/mr2_led/package.xml
+++ b/rover/ros2_ws/src/mr2_led/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>mr2_led</name>
+  <version>0.1.0</version>
+  <description>CAN-controlled LED driver for MR2 (SocketCAN + NeoPixel firmware).</description>
+  <maintainer email="gmmyung@kaist.ac.kr">mr2</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>mr2_can_bus_core</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>mr2_can_bus_core</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rover/ros2_ws/src/mr2_led/src/led_can_node.cpp
+++ b/rover/ros2_ws/src/mr2_led/src/led_can_node.cpp
@@ -1,0 +1,80 @@
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <linux/can.h>
+
+#include "mr2_can_bus_core/can_bus_registry.hpp"
+#include "mr2_led/srv/set_led_mode.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace {
+constexpr uint32_t kStdIdMask = 0x7FF;
+}
+
+class LedCanNode : public rclcpp::Node {
+public:
+  LedCanNode() : rclcpp::Node("mr2_led") {
+    can_iface_ = declare_parameter<std::string>("can_iface", "can0");
+    const int can_id_param = declare_parameter<int>("can_id", 0x123);
+    if (can_id_param < 0 || can_id_param > static_cast<int>(kStdIdMask)) {
+      throw std::runtime_error("Invalid CAN ID: " + std::to_string(can_id_param));
+    }
+    can_id_ = static_cast<uint32_t>(can_id_param);
+
+    bus_ = CanBusRegistry::get(can_iface_);
+    if (!bus_) {
+      throw std::runtime_error("Failed to acquire CAN bus on " + can_iface_);
+    }
+
+    service_ = create_service<mr2_led::srv::SetLedMode>(
+        "set_led_mode",
+        std::bind(&LedCanNode::handle_request_, this, std::placeholders::_1,
+                  std::placeholders::_2, std::placeholders::_3));
+
+    RCLCPP_INFO(get_logger(), "mr2_led ready on %s, StdID 0x%03X", 
+                can_iface_.c_str(), can_id_);
+  }
+
+private:
+  void handle_request_(
+      const std::shared_ptr<rmw_request_id_t> /*request_header*/,
+      const std::shared_ptr<mr2_led::srv::SetLedMode::Request> request,
+      std::shared_ptr<mr2_led::srv::SetLedMode::Response> response) {
+    const auto mode = request->mode;
+    if (mode > mr2_led::srv::SetLedMode::Request::MODE_SUCCESS) {
+      response->success = false;
+      response->message = "Invalid mode";
+      RCLCPP_WARN(get_logger(), "Rejected mode %u", mode);
+      return;
+    }
+
+    struct can_frame frame {};
+    frame.can_id = can_id_ & kStdIdMask;
+    frame.can_dlc = 1;
+    frame.data[0] = mode;
+    bus_->enqueue_tx(frame);
+
+    response->success = true;
+    response->message = "Sent";
+  }
+
+  std::string can_iface_;
+  uint32_t can_id_{0};
+  std::shared_ptr<CanBusManager> bus_;
+  rclcpp::Service<mr2_led::srv::SetLedMode>::SharedPtr service_;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  try {
+    auto node = std::make_shared<LedCanNode>();
+    rclcpp::spin(node);
+  } catch (const std::exception &ex) {
+    RCLCPP_FATAL(rclcpp::get_logger("mr2_led"), "%s", ex.what());
+  }
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rover/ros2_ws/src/mr2_led/srv/SetLedMode.srv
+++ b/rover/ros2_ws/src/mr2_led/srv/SetLedMode.srv
@@ -1,0 +1,9 @@
+uint8 MODE_OFF=0
+uint8 MODE_AUTONOMOUS=1
+uint8 MODE_MANUAL=2
+uint8 MODE_SUCCESS=3
+
+uint8 mode
+---
+bool success
+string message


### PR DESCRIPTION
This pull request introduces a new CAN-controlled LED driver for the MR2 robot, including both STM32 firmware for NeoPixel control and a ROS 2 package (`mr2_led`) that exposes a service interface for LED mode control over CAN. The changes include new firmware, a C++ ROS 2 node, build and launch files, and documentation for both the firmware and the ROS 2 package.

**Key changes:**

### Firmware: STM32 NeoPixel CAN Controller

* Added `led_firmware.ino` for the NUCLEO-G431KB board, which listens for CAN frames (StdID `0x123`) and sets NeoPixel LED modes (off, red, blue, green blink) based on the received mode byte. The firmware supports configuration for pin, LED count, and CAN ID, and includes a detailed `README.md`. [[1]](diffhunk://#diff-6299b42e2836c8ca1e120b855d20344a92aebc4d1bc4a3f13011b45b29a5a814L1-R110) [[2]](diffhunk://#diff-39c7a86dcce01b4f0bc253accf23c87803f5f780cd439f07f0f6c978ef8477bdR1-R57)

### ROS 2 Package: `mr2_led`

* Introduced a new ROS 2 package (`mr2_led`) that provides a service (`SetLedMode`) to control the LED firmware via CAN. The package includes a C++ node (`led_can_node.cpp`) that sends the appropriate CAN frame when the service is called. [[1]](diffhunk://#diff-439f6b53cb4310a01428597a51a58a75117f53f85d4027fedf5ccb67a7fe452bR1-R80) [[2]](diffhunk://#diff-57d304bd5f3c0a0c2ac7d31cfdd0cd64e68cbca64a170eccfdddffb3f88756e7R1-R39) [[3]](diffhunk://#diff-33bc56d832cca39ba83af5e07bd5d70a094ce6072a89b93fc9ae38c9d805d1a3R1-R27)

* Added a custom ROS 2 service definition (`SetLedMode.srv`) with four modes (off, autonomous/red, manual/blue, success/green blink), matching the firmware protocol.

* Provided a launch file (`led_can.launch.py`) for easy startup with configurable CAN interface and ID.

### Documentation

* Added comprehensive `README.md` files for both the firmware and the ROS 2 package, including usage instructions, protocol details, and troubleshooting tips. [[1]](diffhunk://#diff-39c7a86dcce01b4f0bc253accf23c87803f5f780cd439f07f0f6c978ef8477bdR1-R57) [[2]](diffhunk://#diff-30366dda16ac32797752eac77789af7c63d1088bfd808b309fe920efa1fa2311R1-R86)