### PR TITLE
fix can bus manager

### DIFF
--- a/rover/ros2_ws/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_manager.hpp
+++ b/rover/ros2_ws/src/mr2_can_bus_core/include/mr2_can_bus_core/can_bus_manager.hpp
@@ -3,6 +3,7 @@
 // =============================================================
 #pragma once
 
+#include <errno.h>
 #include <fcntl.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
@@ -12,6 +13,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -156,13 +158,37 @@ inline void CanBusManager::io_loop_() {
   while (running_) {
     flush_tx_();
     int n = poll(pfds, 2, 10);
-    if (n <= 0)
+    if (n < 0) {
+      if (errno != EINTR) {
+        // Back off on driver/socket faults to avoid spinning an entire core.
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
       continue;
-    if (pfds[0].revents & POLLIN)
+    }
+    if (n == 0)
+      continue;
+
+    bool handled = false;
+    if (pfds[0].revents & POLLIN) {
       rx_once_();
+      handled = true;
+    }
+    if (pfds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+      handled = true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
     if (pfds[1].revents & POLLIN) {
       char buf[16];
-      read(wake_pipe_[0], buf, sizeof(buf));
+      while (read(wake_pipe_[0], buf, sizeof(buf)) > 0) {
+      }
+      handled = true;
+    }
+    if (pfds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+      handled = true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!handled) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }
 }


### PR DESCRIPTION
This pull request improves the robustness of the CAN bus manager's I/O loop by enhancing error handling and introducing backoff strategies to prevent CPU spinning during faults. Minor header additions also support these improvements.

Error handling and robustness improvements:

* Enhanced error handling in the `io_loop_()` method to distinguish between poll errors and timeouts, introducing a backoff delay for driver/socket faults and poll errors to avoid spinning an entire CPU core.
* Modified wake pipe reading logic to ensure all available data is read, preventing missed wake signals.

Header additions for error handling:

* Added `errno.h` and `chrono` headers to support new error checking and sleep functionality in `can_bus_manager.hpp`. [[1]](diffhunk://#diff-f528c360976771739b9ef8a0604c3d8a9b2de396bfa4ebff61c0ab328a7c0716R6) [[2]](diffhunk://#diff-f528c360976771739b9ef8a0604c3d8a9b2de396bfa4ebff61c0ab328a7c0716R16)