### PR TITLE
Clean rover rosdep manifests and document manual deps

### DIFF
--- a/rover/README.md
+++ b/rover/README.md
@@ -1,5 +1,17 @@
 # Rover
 
+## Manual Dependencies
+
+After running `rosdep` in `rover/ros2_ws`, one runtime dependency is still manual:
+
+```bash
+python3 -m pip install ultralytics
+```
+
+This is required by `mr2_yolo_perception` because
+[yolo_rgbd_detector.py](/home/gmmyung/mr2-stack/rover/ros2_ws/src/mr2_yolo_perception/mr2_yolo_perception/yolo_rgbd_detector.py)
+imports `from ultralytics import YOLO`, and there is no working `rosdep` key for it in this workspace.
+
 ## OpenCV/ROS Humble Repair Notes (Jetson)
 
 ### Problem
@@ -42,4 +54,3 @@ rm -rf build/mr2_rover_auto install/mr2_rover_auto
 source /opt/ros/humble/setup.bash
 colcon build --packages-select mr2_rover_auto
 ```
-

--- a/rover/README.md
+++ b/rover/README.md
@@ -9,7 +9,7 @@ python3 -m pip install ultralytics
 ```
 
 This is required by `mr2_yolo_perception` because
-[yolo_rgbd_detector.py](/home/gmmyung/mr2-stack/rover/ros2_ws/src/mr2_yolo_perception/mr2_yolo_perception/yolo_rgbd_detector.py)
+[yolo_rgbd_detector.py](./ros2_ws/src/mr2_yolo_perception/mr2_yolo_perception/yolo_rgbd_detector.py)
 imports `from ultralytics import YOLO`, and there is no working `rosdep` key for it in this workspace.
 
 ## OpenCV/ROS Humble Repair Notes (Jetson)

--- a/rover/ros2_ws/src/mr2_launch/package.xml
+++ b/rover/ros2_ws/src/mr2_launch/package.xml
@@ -7,6 +7,22 @@
   <maintainer email="gmmyung@kaist.ac.kr">mr2</maintainer>
   <license>MIT</license>
 
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>aruco_opencv</exec_depend>
+  <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>realsense2_camera</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>socat</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>ublox_dgnss</exec_depend>
+  <exec_depend>ublox_dgnss_node</exec_depend>
+  <exec_depend>ublox_nav_sat_fix_hp_node</exec_depend>
+  <exec_depend>v4l2_camera</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/rover/ros2_ws/src/mr2_rover_auto/package.xml
+++ b/rover/ros2_ws/src/mr2_rover_auto/package.xml
@@ -17,8 +17,11 @@
   <!-- Dependencies for what you're launching -->
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
+  <exec_depend>nav2_lifecycle_manager</exec_depend>
+  <exec_depend>nav2_map_server</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
@@ -33,6 +36,7 @@
   <exec_depend>mr2_action_interface</exec_depend>
   <build_depend>aruco_opencv_msgs</build_depend>
   <build_depend>geographiclib</build_depend>
+  <exec_depend>aruco_opencv</exec_depend>
   <exec_depend>aruco_opencv_msgs</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>ublox_ubx_msgs</exec_depend>

--- a/rover/ros2_ws/src/mr2_rover_description/package.xml
+++ b/rover/ros2_ws/src/mr2_rover_description/package.xml
@@ -12,10 +12,13 @@
   <depend>gz_ros2_control_demos</depend>
   <depend>ros2_controllers</depend>
   <depend>ros2_control</depend>
-  <depend>mr2_devices_sensors</depend>
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>mr2_battery_monitor</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>position_controllers</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/rover/ros2_ws/src/mr2_spectrophotometer/package.xml
+++ b/rover/ros2_ws/src/mr2_spectrophotometer/package.xml
@@ -7,13 +7,12 @@
   <maintainer email="gmmyung@kaist.ac.kr">mr2</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>rclpy</depend>
   <depend>mr2_spectrophotometer_msgs</depend>
 
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>v4l-utils</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
 

--- a/rover/ros2_ws/src/mr2_yolo_perception/package.xml
+++ b/rover/ros2_ws/src/mr2_yolo_perception/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="gmmyung@kaist.ac.kr">mr2</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -19,8 +17,6 @@
 
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>
-  <exec_depend>ultralytics</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
## Summary
- remove package.xml entries that block `rosdep` resolution in the rover workspace
- add missing launch/runtime dependencies to rover package manifests
- document the remaining manual Python dependency in `rover/README.md`

## Details
This change makes `rosdep install --from-paths src -y --ignore-src --rosdistro humble` succeed in `rover/ros2_ws`.

It also aligns manifests with actual launch/runtime usage by adding dependencies such as:
- `socat`
- `aruco_opencv`
- `realsense2_camera`
- `rosbridge_server`
- `rviz2`
- `tf2_ros`
- `topic_tools`
- `ublox_dgnss*`
- `nav2_map_server`
- `nav2_lifecycle_manager`
- `controller_manager`
- `robot_state_publisher`
- `ros_gz_bridge`
- `ros_gz_sim`

The remaining unmanaged dependency is `ultralytics`, which is now documented in `rover/README.md` as a manual install.

## Verification
- ran `rosdep install --from-paths src -y --ignore-src --rosdistro humble` in `rover/ros2_ws`
- confirmed there were no remaining launch/package.xml dependency gaps from a workspace scan