### PR TITLE
Require explicit video stream sources

### DIFF
--- a/base/gateway/src/video/stream_config.js
+++ b/base/gateway/src/video/stream_config.js
@@ -83,27 +83,6 @@ function normalizeDisplay(raw = {}, index = 0) {
   return display
 }
 
-function normalizeLegacyRosSource(raw, index) {
-  const rosTopic = assertNonEmptyString(raw.ros_topic, `streams[${index}].ros_topic`)
-  const rosEncoding = assertNonEmptyString(raw.ros_encoding, `streams[${index}].ros_encoding`)
-
-  if (!SUPPORTED_ROS_ENCODINGS.has(rosEncoding)) {
-    throw new Error(
-      `streams[${index}].ros_encoding must be one of ${Array.from(
-        SUPPORTED_ROS_ENCODINGS
-      ).join(', ')}`
-    )
-  }
-
-  return {
-    source_type: 'ros_topic',
-    ros_topic: rosTopic,
-    ros_encoding: rosEncoding,
-    v4l2_device: null,
-    v4l2_pixel_format: null,
-  }
-}
-
 function normalizeTaggedSource(rawSource, index) {
   if (typeof rawSource !== 'object' || rawSource == null || Array.isArray(rawSource)) {
     throw new Error(`streams[${index}].source must be an object`)
@@ -156,10 +135,10 @@ function normalizeTaggedSource(rawSource, index) {
 }
 
 function normalizeSource(raw, index) {
-  if (raw.source != null) {
-    return normalizeTaggedSource(raw.source, index)
+  if (raw.source == null) {
+    throw new Error(`streams[${index}].source is required`)
   }
-  return normalizeLegacyRosSource(raw, index)
+  return normalizeTaggedSource(raw.source, index)
 }
 
 function normalizeStream(raw, index) {

--- a/base/gateway/test/video_stream_config.test.js
+++ b/base/gateway/test/video_stream_config.test.js
@@ -12,15 +12,18 @@ const {
   normalizeVideoConfig,
 } = require('../src/video/stream_config')
 
-test('normalizeVideoConfig accepts legacy ROS streams and preserves metadata', () => {
+test('normalizeVideoConfig accepts tagged ROS sources and preserves metadata', () => {
   const config = normalizeVideoConfig({
     version: 1,
     streams: [
       {
         stream_id: 'front_nav_cam',
-        ros_topic: '/front_camera/image_raw',
+        source: {
+          type: 'ros_topic',
+          ros_topic: '/front_camera/image_raw',
+          ros_encoding: 'rgb8',
+        },
         udp_port: 5000,
-        ros_encoding: 'rgb8',
         width: 640,
         height: 480,
         framerate: 15,
@@ -78,15 +81,21 @@ test('normalizeVideoConfig rejects duplicate identifiers and unsupported encodin
         streams: [
           {
             stream_id: 'front_nav_cam',
-            ros_topic: '/front_camera/image_raw',
+            source: {
+              type: 'ros_topic',
+              ros_topic: '/front_camera/image_raw',
+              ros_encoding: 'rgb8',
+            },
             udp_port: 5000,
-            ros_encoding: 'rgb8',
           },
           {
             stream_id: 'front_nav_cam',
-            ros_topic: '/rgbd_camera/color/image_raw',
+            source: {
+              type: 'ros_topic',
+              ros_topic: '/rgbd_camera/color/image_raw',
+              ros_encoding: 'rgb8',
+            },
             udp_port: 5002,
-            ros_encoding: 'rgb8',
           },
         ],
       }),
@@ -99,13 +108,29 @@ test('normalizeVideoConfig rejects duplicate identifiers and unsupported encodin
         streams: [
           {
             stream_id: 'depth_cam',
-            ros_topic: '/depth/image_raw',
+            source: {
+              type: 'ros_topic',
+              ros_topic: '/depth/image_raw',
+              ros_encoding: 'mono16',
+            },
             udp_port: 5004,
-            ros_encoding: 'mono16',
           },
         ],
       }),
     /ros_encoding/
+  )
+
+  assert.throws(
+    () =>
+      normalizeVideoConfig({
+        streams: [
+          {
+            stream_id: 'missing_source',
+            udp_port: 5006,
+          },
+        ],
+      }),
+    /source is required/
   )
 
   assert.throws(
@@ -150,9 +175,12 @@ test('listBrowserStreams sorts by display order and exposes source metadata', ()
         },
         {
           stream_id: 'first',
-          ros_topic: '/first',
+          source: {
+            type: 'ros_topic',
+            ros_topic: '/first',
+            ros_encoding: 'rgb8',
+          },
           udp_port: 5000,
-          ros_encoding: 'rgb8',
           display: { label: 'First', panel: 'delivery', order: 1 },
           encoder: { bitrate_kbps: 1400 },
         },

--- a/docs/video-pipeline.md
+++ b/docs/video-pipeline.md
@@ -62,10 +62,10 @@ Preferred source forms:
 }
 ```
 
-Current compatibility note:
+Configuration note:
 
-- legacy top-level `ros_topic` + `ros_encoding` entries still load
-- new configs should prefer the explicit `source` object
+- every stream must declare an explicit `source` object
+- top-level `ros_topic` / `ros_encoding` entries are not supported
 
 The intended mapping rule is:
 

--- a/rover/ros2_ws/src/mr2_video_streaming/src/video_streaming_node.cpp
+++ b/rover/ros2_ws/src/mr2_video_streaming/src/video_streaming_node.cpp
@@ -668,25 +668,23 @@ StreamConfig parse_stream_config(const json & item) {
   config.encoder.speed_preset = encoder.value("speed_preset", std::string("ultrafast"));
   config.encoder.tune = encoder.value("tune", std::string("zerolatency"));
 
-  if (item.contains("source")) {
-    const json source = item.at("source");
-    const std::string source_type = source.at("type").get<std::string>();
-    if (source_type == "ros_topic") {
-      config.source_type = StreamSourceType::RosTopic;
-      config.ros_topic = source.at("ros_topic").get<std::string>();
-      config.ros_encoding = source.at("ros_encoding").get<std::string>();
-    } else if (source_type == "v4l2") {
-      config.source_type = StreamSourceType::V4L2;
-      config.v4l2_device = source.at("device").get<std::string>();
-      config.v4l2_pixel_format = source.value("pixel_format", std::string());
-    } else {
-      throw std::runtime_error(
-          "stream " + config.stream_id + " has unsupported source.type " + source_type);
-    }
-  } else {
+  if (!item.contains("source")) {
+    throw std::runtime_error("stream " + config.stream_id + " is missing source");
+  }
+
+  const json source = item.at("source");
+  const std::string source_type = source.at("type").get<std::string>();
+  if (source_type == "ros_topic") {
     config.source_type = StreamSourceType::RosTopic;
-    config.ros_topic = item.at("ros_topic").get<std::string>();
-    config.ros_encoding = item.at("ros_encoding").get<std::string>();
+    config.ros_topic = source.at("ros_topic").get<std::string>();
+    config.ros_encoding = source.at("ros_encoding").get<std::string>();
+  } else if (source_type == "v4l2") {
+    config.source_type = StreamSourceType::V4L2;
+    config.v4l2_device = source.at("device").get<std::string>();
+    config.v4l2_pixel_format = source.value("pixel_format", std::string());
+  } else {
+    throw std::runtime_error(
+        "stream " + config.stream_id + " has unsupported source.type " + source_type);
   }
 
   if (config.source_type == StreamSourceType::RosTopic) {


### PR DESCRIPTION
## Summary
- require every video stream config entry to declare an explicit `source` object
- remove legacy top-level `ros_topic` / `ros_encoding` parsing from the base gateway and rover video node
- update tests and video pipeline docs to match the enforced config shape

## Testing
- `cd base/gateway && npm test`

## Notes
- this PR isolates the post-merge follow-up on top of `2026`, so the diff only contains the explicit-source requirement and not unrelated history from the original video-streaming branch