### PR TITLE
[codex] Tune navigation and map fallback

### DIFF
--- a/rover/ros2_ws/src/mr2_launch/config/realsense_rgbd.yaml
+++ b/rover/ros2_ws/src/mr2_launch/config/realsense_rgbd.yaml
@@ -42,7 +42,7 @@ depth_module.gain.1: 16
 depth_module.exposure.2: 1
 depth_module.gain.2: 16
 
-depth_module.emitter_enabled: 0  # default: 1 # NOTE: sunlight issue ("hidden" in ros2 param list)
+depth_module.emitter_enabled: 1  # default: 1 # IR projector on for low-light depth
 
 enable_sync: false
 depth_module.inter_cam_sync_mode: 0

--- a/rover/ros2_ws/src/mr2_launch/config/video_streams.json
+++ b/rover/ros2_ws/src/mr2_launch/config/video_streams.json
@@ -2,6 +2,32 @@
   "version": 1,
   "streams": [
     {
+      "stream_id": "rgbd_camera",
+      "source": {
+        "type": "v4l2",
+        "device": "/dev/videoRGBD",
+        "pixel_format": "MJPG",
+        "capture_width": 640,
+        "capture_height": 480
+      },
+      "udp_port": 5022,
+      "width": 320,
+      "height": 240,
+      "framerate": 30,
+      "encoder": {
+        "type": "nvv4l2h264enc",
+        "bitrate_kbps": 1800,
+        "keyframe_interval": 30,
+        "speed_preset": "ultrafast",
+        "tune": "zerolatency"
+      },
+      "display": {
+        "label": "RGB-D Cam",
+        "panel": "autonomy",
+        "order": 1
+      }
+    },
+    {
       "stream_id": "top_cam",
       "source": {
         "type": "v4l2",

--- a/rover/ros2_ws/src/mr2_launch/launch/rover_real.launch.py
+++ b/rover/ros2_ws/src/mr2_launch/launch/rover_real.launch.py
@@ -82,7 +82,7 @@ def generate_launch_description():
     enable_autonomous_module_arg = DeclareLaunchArgument(
         "enable_autonomous_module",
         default_value="true",
-        description="Enable autonomous module: launch the UVC front_camera (/dev/videoFRONT) and use it for ArUco detection",
+        description="Enable autonomous module: launch RealSense RGB-D, the UVC front_camera, and autonomous perception/navigation",
     )
     enable_science_module_arg = DeclareLaunchArgument(
         "enable_science_module",
@@ -286,6 +286,7 @@ def generate_launch_description():
             "base_frame_id": "rgbd_camera",
             "urdf_mount_frame": "rgbd_camera",
         }.items(),
+        condition=IfCondition(LaunchConfiguration("enable_autonomous_module")),
     )
 
     front_uvc_launch = IncludeLaunchDescription(

--- a/rover/ros2_ws/src/mr2_rover_auto/config/nav2_params.yaml
+++ b/rover/ros2_ws/src/mr2_rover_auto/config/nav2_params.yaml
@@ -112,8 +112,8 @@ controller_server:
       batch_size: 500 # 2000 # Hopefully use less CPU
       vx_std: 0.2
       vy_std: 0.2
-      wz_std: 0.4
-      vx_max: 0.6
+      wz_std: 0.25
+      vx_max: 0.8
       vx_min: -0.35
       vy_max: 0.6
       wz_max: 0.9 # NOTE: RADIUS = 0.57725 (#34)
@@ -383,8 +383,8 @@ velocity_smoother:
     smoothing_frequency: 20.0
     scale_velocities: False
     feedback: "OPEN_LOOP" # XXX: Setting "CLOSED_LOOP" gives 0.125 max vel (???)
-    max_velocity: [0.6, 0.6, 0.9] # NOTE: RADIUS = 0.57725 (#34)
-    min_velocity: [-0.6, -0.6, -0.9]
+    max_velocity: [0.8, 0.6, 0.9] # NOTE: RADIUS = 0.57725 (#34)
+    min_velocity: [-0.35, -0.6, -0.9]
     max_accel: [2.5, 2.5, 0.8] # Conservative ang. acc; high steering response delay
     max_decel: [-2.5, -2.5, -0.8]
     odom_topic: "odom"

--- a/rover/ros2_ws/src/mr2_rover_auto/src/map_cropper.cpp
+++ b/rover/ros2_ws/src/mr2_rover_auto/src/map_cropper.cpp
@@ -147,6 +147,7 @@ public:
     from_ll_response_timeout_s_ = this->declare_parameter<double>("from_ll_response_timeout_s", 5.0);
 
     roi_padding_m_ = this->declare_parameter<double>("roi_padding_m", 100.0);
+    blank_map_max_side_m_ = this->declare_parameter<double>("blank_map_max_side_m", 4000.0);
     load_map_wait_timeout_s_ = this->declare_parameter<double>("load_map_wait_timeout_s", 3.0);
     load_map_response_timeout_s_ = this->declare_parameter<double>("load_map_response_timeout_s", 10.0);
 
@@ -333,6 +334,12 @@ private:
     return max_index + 1;
   }
 
+  bool source_map_contains(double x, double y) const
+  {
+    return x >= metadata_.min_x && x <= metadata_.max_x &&
+           y >= metadata_.min_y && y <= metadata_.max_y;
+  }
+
   bool compute_crop_bounds(
     double current_x,
     double current_y,
@@ -400,6 +407,49 @@ private:
     out_bounds->row_end = row_end;
     out_bounds->origin_x = origin_x;
     out_bounds->origin_y = origin_y;
+    out_bounds->side_length_m = std::min(realized_side_x, realized_side_y);
+    return true;
+  }
+
+  bool compute_blank_bounds(
+    double current_x,
+    double current_y,
+    double goal_x,
+    double goal_y,
+    CropBounds * out_bounds,
+    std::string * error_msg) const
+  {
+    if (blank_map_max_side_m_ <= kEpsilon) {
+      *error_msg = "blank_map_max_side_m must be positive";
+      return false;
+    }
+
+    const double distance_m = std::hypot(goal_x - current_x, goal_y - current_y);
+    double side_m = distance_m + roi_padding_m_;
+    side_m = std::max(side_m, std::max(metadata_.resolution_x, metadata_.resolution_y));
+
+    if (side_m > blank_map_max_side_m_) {
+      std::ostringstream oss;
+      oss << "Requested blank map side " << side_m
+          << " m exceeds blank_map_max_side_m " << blank_map_max_side_m_ << " m";
+      *error_msg = oss.str();
+      return false;
+    }
+
+    const int side_cols = std::max(1, static_cast<int>(std::ceil(side_m / metadata_.resolution_x)));
+    const int side_rows = std::max(1, static_cast<int>(std::ceil(side_m / metadata_.resolution_y)));
+    const double realized_side_x = static_cast<double>(side_cols) * metadata_.resolution_x;
+    const double realized_side_y = static_cast<double>(side_rows) * metadata_.resolution_y;
+
+    const double center_x = 0.5 * (current_x + goal_x);
+    const double center_y = 0.5 * (current_y + goal_y);
+
+    out_bounds->col_start = 0;
+    out_bounds->col_end = side_cols;
+    out_bounds->row_start = 0;
+    out_bounds->row_end = side_rows;
+    out_bounds->origin_x = center_x - 0.5 * realized_side_x;
+    out_bounds->origin_y = center_y - 0.5 * realized_side_y;
     out_bounds->side_length_m = std::min(realized_side_x, realized_side_y);
     return true;
   }
@@ -596,25 +646,60 @@ private:
     const double current_image_y = current_y - image_center_map_y;
     const double goal_image_x = goal_x - image_center_map_x;
     const double goal_image_y = goal_y - image_center_map_y;
+    const bool source_covers_request =
+      source_map_contains(current_image_x, current_image_y) &&
+      source_map_contains(goal_image_x, goal_image_y);
 
     CropBounds bounds;
-    if (!compute_crop_bounds(
-        current_image_x, current_image_y, goal_image_x, goal_image_y, &bounds, &error_msg))
-    {
-      response->message = error_msg;
-      return;
+    cv::Mat map_image;
+    double origin_map_x = 0.0;
+    double origin_map_y = 0.0;
+    const char * map_kind = "crop";
+    bool generated_blank = false;
+
+    if (source_covers_request) {
+      if (!compute_crop_bounds(
+          current_image_x, current_image_y, goal_image_x, goal_image_y, &bounds, &error_msg))
+      {
+        response->message = error_msg;
+        return;
+      }
+
+      origin_map_x = bounds.origin_x + image_center_map_x;
+      origin_map_y = bounds.origin_y + image_center_map_y;
+
+      const int crop_width = bounds.col_end - bounds.col_start;
+      const int crop_height = bounds.row_end - bounds.row_start;
+
+      const auto crop_rect = cv::Rect(bounds.col_start, bounds.row_start, crop_width, crop_height);
+      map_image = source_map_(crop_rect).clone();
+      if (map_image.empty()) {
+        response->message = "Failed to extract crop image";
+        return;
+      }
+    } else {
+      if (!compute_blank_bounds(current_x, current_y, goal_x, goal_y, &bounds, &error_msg)) {
+        response->message = error_msg;
+        return;
+      }
+
+      origin_map_x = bounds.origin_x;
+      origin_map_y = bounds.origin_y;
+      const int blank_width = bounds.col_end - bounds.col_start;
+      const int blank_height = bounds.row_end - bounds.row_start;
+      map_image = cv::Mat(blank_height, blank_width, CV_8UC1, cv::Scalar(0));
+      map_kind = "blank";
+      generated_blank = true;
+
+      RCLCPP_WARN(
+        get_logger(),
+        "Source map does not cover request; generating blank map (current_image=[%.3f, %.3f], goal_image=[%.3f, %.3f], source_extent=[%.3f, %.3f]..[%.3f, %.3f])",
+        current_image_x, current_image_y, goal_image_x, goal_image_y,
+        metadata_.min_x, metadata_.min_y, metadata_.max_x, metadata_.max_y);
     }
 
-    const double origin_map_x = bounds.origin_x + image_center_map_x;
-    const double origin_map_y = bounds.origin_y + image_center_map_y;
-
-    const int crop_width = bounds.col_end - bounds.col_start;
-    const int crop_height = bounds.row_end - bounds.row_start;
-
-    const auto crop_rect = cv::Rect(bounds.col_start, bounds.row_start, crop_width, crop_height);
-    const cv::Mat crop = source_map_(crop_rect).clone();
-    if (crop.empty()) {
-      response->message = "Failed to extract crop image";
+    if (map_image.empty()) {
+      response->message = "Generated map image is empty";
       return;
     }
 
@@ -624,8 +709,8 @@ private:
     const auto output_png = std::filesystem::path(output_dir_) / (stem + ".png");
     const auto output_yaml = std::filesystem::path(output_dir_) / (stem + ".yaml");
 
-    if (!cv::imwrite(output_png.string(), crop)) {
-      response->message = "Failed to write crop image: " + output_png.string();
+    if (!cv::imwrite(output_png.string(), map_image)) {
+      response->message = "Failed to write map image: " + output_png.string();
       return;
     }
 
@@ -657,12 +742,12 @@ private:
     response->roi_side_length_m = bounds.side_length_m;
     response->map_origin_x = origin_map_x;
     response->map_origin_y = origin_map_y;
-    response->message = "Crop generated and loaded";
+    response->message = generated_blank ? "Blank map generated and loaded" : "Crop generated and loaded";
 
     RCLCPP_INFO(
       get_logger(),
-      "Generated %s and loaded %s (current_map=[%.3f, %.3f], goal_map=[%.3f, %.3f], image_center_map=[%.3f, %.3f], origin_map=[%.3f, %.3f], side=%.3f m)",
-      output_png.c_str(), output_yaml.c_str(), current_x, current_y, goal_x, goal_y,
+      "Generated %s %s and loaded %s (current_map=[%.3f, %.3f], goal_map=[%.3f, %.3f], image_center_map=[%.3f, %.3f], origin_map=[%.3f, %.3f], side=%.3f m)",
+      map_kind, output_png.c_str(), output_yaml.c_str(), current_x, current_y, goal_x, goal_y,
       image_center_map_x, image_center_map_y, origin_map_x, origin_map_y, bounds.side_length_m);
   }
 
@@ -684,6 +769,7 @@ private:
   double image_center_map_y_{0.0};
 
   double roi_padding_m_{100.0};
+  double blank_map_max_side_m_{4000.0};
   double tf_timeout_s_{0.2};
   double from_ll_wait_timeout_s_{2.0};
   double from_ll_response_timeout_s_{5.0};

--- a/rover/ros2_ws/src/mr2_rover_description/config/controllers/rover_controllers.yaml
+++ b/rover/ros2_ws/src/mr2_rover_description/config/controllers/rover_controllers.yaml
@@ -45,7 +45,7 @@ rover_controller:
     solver_cmd_deadzone_lin: 0.001  # m/s
     solver_cmd_deadzone_ang: 0.001  # rad/s
     solver_vel_eps: 0.0001          # m/s
-    mission_smooth: true            # true: Use solver smoothing when mission state == RUNNING
+    mission_smooth: false           # Use the same steering conversion in mission and nominal driving
     # Wheel odometry masks (order: FL, FR, RL, RR). Use to ignore dead/dummy wheels.
     odom_wheel_drive_enabled: [true, false, true, true] # XXX: FR false for 2026. 02. 21 incident
     odom_wheel_steer_enabled: [true, true, true, true]

--- a/scripts/99-mr2-serial.rules
+++ b/scripts/99-mr2-serial.rules
@@ -8,6 +8,8 @@
 # SUBSYSTEM=="tty", KERNEL=="ttyACM*", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a9", MODE:="0666", GROUP:="plugdev"
 #######################################################################
 SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{serial}=="D30JZD4O", MODE:="0666", GROUP:="dialout", SYMLINK+="ttyXBEE"
+# RealSense D435i RGB stream — map only the RGB capture node (interface 03, index 0).
+SUBSYSTEM=="video4linux", KERNEL=="video*", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0b3a", ATTRS{serial}=="351623060934", ENV{ID_USB_INTERFACE_NUM}=="03", ATTR{index}=="0", MODE:="0666", GROUP:="video", SYMLINK+="videoRGBD"
 # Front camera (Suyin rev 0x5805, USB path 2.3) — map only the capture node (index 0)
 SUBSYSTEM=="video4linux", KERNEL=="video*", ATTRS{idVendor}=="1e45", ATTRS{idProduct}=="8022", ATTRS{bcdDevice}=="5805", ATTRS{serial}=="200910120001", ATTRS{devpath}=="2.3", ATTR{index}=="0", MODE:="0666", GROUP:="video", SYMLINK+="videoFRONT"
 # Gripper camera via hub on front-camera USB port (Suyin rev 0x5805, USB path 2.3.2) — map only the capture node (index 0)


### PR DESCRIPTION
## Summary

- Enable the RealSense IR emitter by default.
- Raise Nav2 forward speed to 0.8 m/s and reduce angular MPPI sampling to reduce left-right hunting.
- Make mission-mode rover steering use the nominal steering conversion path by disabling `mission_smooth`.
- Add a `map_cropper` fallback that generates and loads a blank free-space map when the source terrain map does not cover the current robot/goal request.

## Why

The rover was being tested outside the source terrain map area, which could load a crop whose bounds did not contain the localized robot. Nav2 then failed with `Robot is out of bounds of the costmap` and `Start Coordinates were outside map bounds`. The fallback keeps the map bounds valid for out-of-region operation while preserving terrain-map crops when the source map covers the request.

## Validation

- `colcon build --packages-select mr2_rover_auto --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- YAML parse check for `nav2_params.yaml` and `rover_controllers.yaml`
- `git diff --check` on changed files

Note: the `mr2_rover_auto` build emitted existing GCC notes from unrelated cover-vision adapter files, but completed successfully.